### PR TITLE
Fix spelling and doc details

### DIFF
--- a/docs/source/decoder_c_api.rst
+++ b/docs/source/decoder_c_api.rst
@@ -15,7 +15,7 @@ The VGF file has the following sections in the order specified (see enum ``mlsdk
 
 Each section of the VGF has its own decoder type. The memory requirement for each section decoder is retrieved by the corresponding calls, for example, function ``mlsdk_decoder_module_table_decoder_mem_reqs`` for Module section.
 Each section of the VGF has its corresponding call for creating its decoder, for example, ``mlsdk_decoder_create_module_table_decoder`` function for Module section. Then, the created decoder reads data pertaining to that VGF section.
-If the VGF file is obtained from an external source and potentially unsafe, each section has its own verfier, for example  ``mlsdk_decoder_is_valid_module_table``.
+If the VGF file is obtained from an external source and potentially unsafe, each section has its own verifier, for example  ``mlsdk_decoder_is_valid_module_table``.
 
 .. figure:: assets/c_decoder_main.svg
    :align: center
@@ -26,7 +26,7 @@ If the VGF file is obtained from an external source and potentially unsafe, each
 Modules Section
 ```````````````
 ``mlsdk_decoder_get_module_table_num_entries`` can use a module table decoder to retrieve the number of modules in a VGF file.
-Currently, the modules are SPIRV-V™ modules only.
+Currently, the modules are SPIR-V™ modules only.
 You can use the following functions to retrieve module information through a module table decoder:
 
     * **Name**: ``mlsdk_decoder_get_module_name``

--- a/docs/source/logging_api.rst
+++ b/docs/source/logging_api.rst
@@ -2,7 +2,7 @@ VGF Logging C++ API
 ===================
 
 
-The VGF Library produces logging messages. The Logging C API allows you to process these logging messages. To enable the logging functionality, you must provide the callback function. The callback function accepts log level and message as input parameters:
+The VGF Library produces logging messages. The Logging C++ API allows you to process these logging messages. To enable the logging functionality, you must provide the callback function. The callback function accepts log level and message as input parameters:
 
 .. code-block:: cpp
 

--- a/docs/source/logging_c_api.rst
+++ b/docs/source/logging_c_api.rst
@@ -1,7 +1,7 @@
 VGF Logging C API
 ===================
 
-The VGF Library produces logging messages. The Logging C++ API allows you to process these logging messages. To enable the logging functionality, you must provide the callback function. The callback function accepts log level and message as input parameters:
+The VGF Library produces logging messages. The Logging C API allows you to process these logging messages. To enable the logging functionality, you must provide the callback function. The callback function accepts log level and message as input parameters:
 
 .. code-block:: cpp
 


### PR DESCRIPTION
Fix spelling in documentation

Change-Id: Ibab31774404339971d4ea3be4282c1c9c0bcdc8d