### PR TITLE
Add support for large models

### DIFF
--- a/include/vgf/decoder.hpp
+++ b/include/vgf/decoder.hpp
@@ -352,7 +352,7 @@ size_t ConstantDecoderSize();
 /**
  * @brief Returns true if input points to a valid Constant section
  *
- * @param data
+ * @param data Pointer to the Constants section data
  * @param size Max count of read bytes
  */
 bool VerifyConstant(const void *data, uint64_t size);

--- a/schema/vgf.fbs
+++ b/schema/vgf.fbs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -87,12 +87,14 @@ table ModelSequenceTable {
     output_names: [string];
 }
 
+// This section is deprecated and is kept for backward compatibility
 table ConstantData {
     mrt_index: uint;
     sparsity_dimension: int64;
     raw: [ubyte] (force_align: 8);
 }
 
+// This section is deprecated and is kept for backward compatibility
 table ConstantSection {
     data: [ConstantData];
 }

--- a/src/constant.hpp
+++ b/src/constant.hpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <numeric>
+#include <vector>
+
+namespace mlsdk::vgflib {
+
+constexpr const char CONSTANT_SECTION_VERSION[8] = {'C', 'O', 'N', 'S', 'T', '0', '0', '\0'};
+constexpr size_t CONSTANT_SECTION_VERSION_OFFSET = 0;
+constexpr size_t CONSTANT_SECTION_VERSION_SIZE = 8;
+static_assert(sizeof(CONSTANT_SECTION_VERSION) == CONSTANT_SECTION_VERSION_SIZE);
+
+constexpr size_t CONSTANT_SECTION_COUNT_OFFSET = CONSTANT_SECTION_VERSION_OFFSET + CONSTANT_SECTION_VERSION_SIZE;
+constexpr size_t CONSTANT_SECTION_COUNT_SIZE = 8;
+
+constexpr size_t CONSTANT_SECTION_METADATA_OFFSET = CONSTANT_SECTION_COUNT_OFFSET + CONSTANT_SECTION_COUNT_SIZE;
+
+constexpr size_t CONSTANT_SECTION_METADATA_MRT_INDEX_SIZE = 4;
+constexpr size_t CONSTANT_SECTION_METADATA_MRT_INDEX_OFFSET = 0;
+
+constexpr size_t CONSTANT_SECTION_METADATA_SPARSITY_DIMENSION_SIZE = 4;
+constexpr size_t CONSTANT_SECTION_METADATA_SPARSITY_DIMENSION_OFFSET =
+    CONSTANT_SECTION_METADATA_MRT_INDEX_OFFSET + CONSTANT_SECTION_METADATA_MRT_INDEX_SIZE;
+
+constexpr size_t CONSTANT_SECTION_METADATA_SIZE_SIZE = 8;
+constexpr size_t CONSTANT_SECTION_METADATA_SIZE_OFFSET =
+    CONSTANT_SECTION_METADATA_SPARSITY_DIMENSION_OFFSET + CONSTANT_SECTION_METADATA_SPARSITY_DIMENSION_SIZE;
+
+constexpr size_t CONSTANT_SECTION_METADATA_OFFSET_SIZE = 8;
+constexpr size_t CONSTANT_SECTION_METADATA_OFFSET_OFFSET =
+    CONSTANT_SECTION_METADATA_SIZE_OFFSET + CONSTANT_SECTION_METADATA_SIZE_SIZE;
+
+struct ConstantMetaData_V00 {
+    uint32_t mrtIndex{};
+    int32_t sparsityDimension{-1};
+    uint64_t size{};
+    uint64_t offset{};
+};
+static_assert(sizeof(ConstantMetaData_V00) % 8 == 0);
+static_assert(sizeof(ConstantMetaData_V00) == sizeof(uint32_t) + sizeof(int32_t) + sizeof(uint64_t) + sizeof(uint64_t));
+
+static_assert(offsetof(ConstantMetaData_V00, mrtIndex) == CONSTANT_SECTION_METADATA_MRT_INDEX_OFFSET,
+              "ConstantMetaData mrtIndex field offset mismatched from spec.");
+static_assert(offsetof(ConstantMetaData_V00, sparsityDimension) == CONSTANT_SECTION_METADATA_SPARSITY_DIMENSION_OFFSET,
+              "ConstantMetaData sparsityDimension field offset mismatched from spec.");
+static_assert(offsetof(ConstantMetaData_V00, size) == CONSTANT_SECTION_METADATA_SIZE_OFFSET,
+              "ConstantMetaData size field offset mismatched from spec.");
+static_assert(offsetof(ConstantMetaData_V00, offset) == CONSTANT_SECTION_METADATA_OFFSET_OFFSET,
+              "ConstantMetaData offset field offset mismatched from spec.");
+} // namespace mlsdk::vgflib

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -66,7 +66,7 @@ constexpr size_t HEADER_CONSTANT_SECTION_OFFSET_OFFSET =
 constexpr size_t HEADER_CONSTANT_SECTION_SIZE_OFFSET = HEADER_CONSTANT_SECTION_OFFSET + offsetof(SectionEntry, size);
 
 constexpr uint8_t HEADER_MAJOR_VERSION_VALUE = 0;
-constexpr uint8_t HEADER_MINOR_VERSION_VALUE = 3;
+constexpr uint8_t HEADER_MINOR_VERSION_VALUE = 4;
 constexpr uint8_t HEADER_PATCH_VERSION_VALUE = 0;
 
 // This is a reminder to trigger removal of deprecated features on major version bump


### PR DESCRIPTION
* This adds another implementation of the decoder class which is not a FlatBuffers section while keeping the previous implementation as well. To distinguish between the two during decoding a versioned header is added to the new constant section so we can identify which decoder implementation to choose when parsing. This way the large constants will be encoded in the section itself.

Change-Id: Iae7459024520824edf5e670db2b7b802cd647811