### PR TITLE
Enable clang-tidy banned function checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@
 #
 Checks: >
     -*,
+    bugprone-unsafe-functions,
     bugprone-use-after-move,
     cert-con36-c,
     cert-con54-cpp,
@@ -107,6 +108,21 @@ WarningsAsErrors: '*'
 HeaderFilterRegex: 'vgf-lib/.+/.+\.hpp$'
 FormatStyle: file
 CheckOptions:
+  - key: bugprone-unsafe-functions.ReportDefaultFunctions
+    value: 'true'
+  - key: bugprone-unsafe-functions.ReportMoreUnsafeFunctions
+    value: 'true'
+  - key: bugprone-unsafe-functions.CustomFunctions
+    value: >
+      ^alloca$,malloc or new,is considered unsafe;
+      ^readdir$,,>is considered unsafe; use a safer wrapper or explicit directory iteration API;
+      ^_tscanf$,,>is considered unsafe; use fgets-based parsing instead;
+      ^_stscanf$,,>is considered unsafe; use fgets-based parsing instead;
+      ^StrCpy$,strcpy_s,is considered unsafe;
+      ^lstrcpy$,strcpy_s,is considered unsafe;
+      ^StrCpyN$,strncpy_s,is considered unsafe;
+      ^StrNCpy$,strncpy_s,is considered unsafe;
+      ^lstrcpyn$,strncpy_s,is considered unsafe
   - key: readability-identifier-naming.ClassMemberCase
     value: camelBack
   - key: readability-identifier-naming.ClassMemberSuffix

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -298,6 +298,7 @@ class Builder:
 
                 clang_tidy_cmd = [
                     "run-clang-tidy",
+                    "-quiet",
                     f"-j{self.threads}",
                     f"-p{self.build_dir}",
                     "-extra-arg=-Wno-ignored-optimization-argument",


### PR DESCRIPTION
Add clang-tidy unsafe-function checking to the existing lint configuration by enabling bugprone-unsafe-functions and adding the project-specific banned function list. Also enable ReportMoreUnsafeFunctions for broader default coverage.

Update the lint build scripts to run clang-tidy in quiet mode so CI output stays focused on actionable diagnostics.
