### PR TITLE
Add missing bug-fix lists to release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,13 @@
 - Added a CMake option to build the VGF shared library.
 - Updated fuzzer build integration and disabled `vgf_fuzzer` by default.
 
+### Bug Fixes
+
+- Fixed `vgf_dump` scenario output to stop emitting the obsolete `frame_id`
+  field.
+- Fixed decoder API size handling mismatches across the C and C++ entry points.
+- Fixed README `tooling-requirements` path references.
+
 ## Version 0.8.0 – *Updater & Tooling Update*
 
 ### Highlights
@@ -43,6 +50,14 @@
 
 - Added Darwin targets for AArch64 to the pip packaging matrix.
 - Refreshed SBOM data and adopted usage of `REUSE.toml`.
+
+### Bug Fixes
+
+- Fixed missing package version initialization, bad package names, and
+  SDK-root `--install` packaging failures.
+- Fixed non-zero exit handling in the pip package flow.
+- Fixed constant-memory release after writing decoder output files.
+- Fixed incorrect dependency versions in the SBOM data.
 
 ### Supported Platforms
 


### PR DESCRIPTION
Document the missing bug-fix highlights for the 0.8.0 and 0.9.0 releases.

Change-Id: I34c2d63e8fe93426bed49c61a4b4aebc2ea9be70