### PR TITLE
Add sampler metadata support via ExtraConfig union

### DIFF
--- a/include-c/vgf/decoder.h
+++ b/include-c/vgf/decoder.h
@@ -51,6 +51,7 @@ typedef struct mlsdk_decoder_model_sequence_decoder_s *mlsdk_decoder_model_seque
 typedef struct mlsdk_decoder_model_resource_table_decoder_s *mlsdk_decoder_model_resource_table_decoder;
 typedef struct mlsdk_decoder_constant_table_decoder_s *mlsdk_decoder_constant_table_decoder;
 typedef struct mlsdk_decoder_names_handle_s const *mlsdk_decoder_names_handle;
+typedef struct mlsdk_decoder_sampler_config_handle_s const *mlsdk_decoder_sampler_config_handle;
 
 /**
  * \defgroup VGFCAPI Decoder C API
@@ -832,6 +833,71 @@ MLSDKAPI void mlsdk_decoder_model_resource_table_get_tensor_shape(
 MLSDKAPI void mlsdk_decoder_model_resource_table_get_tensor_strides(
     const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t mrtIdx,
     mlsdk_decoder_tensor_dimensions *dimensions);
+
+/**
+ * @brief Returns a sampler-config handle for sampled-image resources
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param mrtIdx The index for the entry in the model resource table
+ * @return Handle to sampler config, or nullptr when absent
+ */
+MLSDKAPI mlsdk_decoder_sampler_config_handle mlsdk_decoder_model_resource_table_get_sampler_config_handle(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t mrtIdx);
+
+/**
+ * @brief Returns VkFilter min filter value from sampler config handle
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param handle Handle to sampler config. Must not be nullptr.
+ * @return VkFilter min filter value
+ */
+MLSDKAPI uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_min_filter(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle);
+
+/**
+ * @brief Returns VkFilter mag filter value from sampler config handle
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param handle Handle to sampler config. Must not be nullptr.
+ * @return VkFilter mag filter value
+ */
+MLSDKAPI uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_mag_filter(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle);
+
+/**
+ * @brief Returns VkSamplerAddressMode U value from sampler config handle
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param handle Handle to sampler config. Must not be nullptr.
+ * @return VkSamplerAddressMode U value
+ */
+MLSDKAPI uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_u(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle);
+
+/**
+ * @brief Returns VkSamplerAddressMode V value from sampler config handle
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param handle Handle to sampler config. Must not be nullptr.
+ * @return VkSamplerAddressMode V value
+ */
+MLSDKAPI uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_v(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle);
+
+/**
+ * @brief Returns VkBorderColor value from sampler config handle
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param handle Handle to sampler config. Must not be nullptr.
+ * @return VkBorderColor value
+ */
+MLSDKAPI uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_border_color(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle);
 
 /**********************************************************************************************************************/
 

--- a/include/vgf/decoder.hpp
+++ b/include/vgf/decoder.hpp
@@ -328,6 +328,9 @@ std::unique_ptr<ModuleTableDecoder> CreateModuleTableDecoder(const void *data, u
 ModuleTableDecoder *CreateModuleTableDecoderInPlace(const void *data, uint64_t size, void *decoderMem);
 
 // ModelResourceTableDecoder
+struct SamplerConfigHandle_s {};
+using SamplerConfigHandle = const SamplerConfigHandle_s *;
+
 class ModelResourceTableDecoder {
   public:
     virtual ~ModelResourceTableDecoder() = default;
@@ -371,6 +374,49 @@ class ModelResourceTableDecoder {
      * @param id
      */
     virtual DataView<int64_t> getTensorStride(uint32_t id) const = 0;
+
+    /**
+     * @brief Returns a handle to the sampler config for MRT entry 'id'
+     *
+     * @param id
+     * @returns nullptr when no sampler config is present
+     */
+    virtual SamplerConfigHandle getSamplerConfigHandle(uint32_t id) const = 0;
+
+    /**
+     * @brief Returns VkFilter min filter value from sampler config handle
+     *
+     * @param handle
+     */
+    virtual uint32_t getSamplerConfigMinFilter(SamplerConfigHandle handle) const = 0;
+
+    /**
+     * @brief Returns VkFilter mag filter value from sampler config handle
+     *
+     * @param handle
+     */
+    virtual uint32_t getSamplerConfigMagFilter(SamplerConfigHandle handle) const = 0;
+
+    /**
+     * @brief Returns VkSamplerAddressMode U value from sampler config handle
+     *
+     * @param handle
+     */
+    virtual uint32_t getSamplerConfigAddressModeU(SamplerConfigHandle handle) const = 0;
+
+    /**
+     * @brief Returns VkSamplerAddressMode V value from sampler config handle
+     *
+     * @param handle
+     */
+    virtual uint32_t getSamplerConfigAddressModeV(SamplerConfigHandle handle) const = 0;
+
+    /**
+     * @brief Returns VkBorderColor value from sampler config handle
+     *
+     * @param handle
+     */
+    virtual uint32_t getSamplerConfigBorderColor(SamplerConfigHandle handle) const = 0;
 };
 
 /**

--- a/include/vgf/encoder.hpp
+++ b/include/vgf/encoder.hpp
@@ -123,6 +123,18 @@ class Encoder {
     virtual ResourceRef AddConstantResource(FormatType vkFormat, const std::vector<int64_t> &shape,
                                             const std::vector<int64_t> &strides) = 0;
 
+    /// \brief Set sampler metadata for an existing model resource table entry
+    ///
+    /// \param resource Resource reference used in model resource table
+    /// \param samplerMinFilter VkFilter value for sampled images
+    /// \param samplerMagFilter VkFilter value for sampled images
+    /// \param samplerAddressModeU VkSamplerAddressMode for U axis
+    /// \param samplerAddressModeV VkSamplerAddressMode for V axis
+    /// \param samplerBorderColor VkBorderColor value
+    virtual void AddSamplerConfig(ResourceRef resource, uint32_t samplerMinFilter, uint32_t samplerMagFilter,
+                                  uint32_t samplerAddressModeU, uint32_t samplerAddressModeV,
+                                  uint32_t samplerBorderColor) = 0;
+
     /// \brief Add constant values to a constant resource type in the model resource table
     ///
     /// \param resource Resource reference used in model resource table

--- a/include/vgf/types.hpp
+++ b/include/vgf/types.hpp
@@ -78,6 +78,28 @@ using DescriptorType = int32_t;
  */
 using FormatType = int32_t;
 
+/**
+ * \brief VGF type that corresponds to a VkFilter enum of the Vulkan API
+ *
+ * See ToFilterType and ToVkFilter in vulkan_helpers.generated.hpp
+ */
+using FilterType = int32_t;
+
+/**
+ * \brief VGF type that corresponds to a VkSamplerAddressMode enum of the Vulkan API
+ *
+ * See ToSamplerAddressModeType and ToVkSamplerAddressMode in
+ * vulkan_helpers.generated.hpp
+ */
+using SamplerAddressModeType = int32_t;
+
+/**
+ * \brief VGF type that corresponds to a VkBorderColor enum of the Vulkan API
+ *
+ * See ToBorderColorType and ToVkBorderColor in vulkan_helpers.generated.hpp
+ */
+using BorderColorType = int32_t;
+
 /// \brief Value that corresponds to an Undefined VkFormat.
 constexpr FormatType UndefinedFormat() { return 0; }
 

--- a/include/vgf/vulkan_helpers.generated.hpp
+++ b/include/vgf/vulkan_helpers.generated.hpp
@@ -26,7 +26,7 @@
 namespace mlsdk::vgflib {
 
 // Record the VK_HEADER_VERSION from the vulkan_core.h used to generate this file
-const int32_t HEADER_VERSION_USED_FOR_HELPER_GENERATION = 338;
+const int32_t HEADER_VERSION_USED_FOR_HELPER_GENERATION = 345;
 
 #if defined(VGFLIB_VK_HELPERS)
 using VkDescriptorType = int32_t;
@@ -2067,6 +2067,256 @@ inline bool ValidateDecodedFormatType(FormatType e) {
     case 1000609013: // VK_FORMAT_G14X2_B14X2R14X2_2PLANE_422_UNORM_3PACK16_ARM
     case 1000658000: // VK_FORMAT_SBS80_ARM
     case 0x7FFFFFFF: // VK_FORMAT_MAX_ENUM
+        return true;
+    default:
+        return false;
+    }
+}
+
+#if defined(VGFLIB_VK_HELPERS)
+using VkFilter = int32_t;
+#endif
+
+// Cast a VkFilter type to a FilterType type
+inline FilterType ToFilterType(VkFilter e) { return static_cast<FilterType>(e); }
+
+// Cast a FilterType type to a VkFilter type
+inline VkFilter ToVkFilter(FilterType e) { return static_cast<VkFilter>(e); }
+
+// Ensure validity of casted types
+static_assert(sizeof(VkFilter) == sizeof(FilterType));
+
+// Convert a FilterType enum value to cstring name
+inline std::string FilterTypeToName(FilterType e) {
+    switch (static_cast<int>(e)) {
+    case 0:
+        return "VK_FILTER_NEAREST";
+    case 1:
+        return "VK_FILTER_LINEAR";
+    case 1000015000:
+        return "VK_FILTER_CUBIC_EXT / VK_FILTER_CUBIC_IMG";
+    case 0x7FFFFFFF:
+        return "VK_FILTER_MAX_ENUM";
+    default: {
+        std::stringstream ss;
+        ss << "Unknown(" << e << ")";
+        return ss.str();
+    }
+    }
+}
+
+// Convert a string name to FilterTypeenum value
+inline FilterType NameToFilterType(const std::string &str) {
+    if (str == "VK_FILTER_NEAREST") {
+        return 0;
+    }
+    if (str == "VK_FILTER_LINEAR") {
+        return 1;
+    }
+    if (str == "VK_FILTER_CUBIC_EXT") {
+        return 1000015000;
+    }
+    if (str == "VK_FILTER_CUBIC_IMG") {
+        return 1000015000;
+    }
+    if (str == "VK_FILTER_MAX_ENUM") {
+        return 0x7FFFFFFF;
+    }
+    // Unknown name
+    return -1;
+}
+
+// Validate that the decoded enum is valid given the Vulkan headers version in use. If this call
+// fails, it indicates that either a newer vulkan_core.h was used by the VGF generator OR that the
+// VGF is corrupted in some other way. Regenerating this header file with a newer Vulkan headers
+// version may resolve the issue.
+inline bool ValidateDecodedFilterType(FilterType e) {
+    switch (static_cast<int>(e)) {
+    case 0:          // VK_FILTER_NEAREST
+    case 1:          // VK_FILTER_LINEAR
+    case 1000015000: // VK_FILTER_CUBIC_EXT / VK_FILTER_CUBIC_IMG
+    case 0x7FFFFFFF: // VK_FILTER_MAX_ENUM
+        return true;
+    default:
+        return false;
+    }
+}
+
+#if defined(VGFLIB_VK_HELPERS)
+using VkSamplerAddressMode = int32_t;
+#endif
+
+// Cast a VkSamplerAddressMode type to a SamplerAddressModeType type
+inline SamplerAddressModeType ToSamplerAddressModeType(VkSamplerAddressMode e) {
+    return static_cast<SamplerAddressModeType>(e);
+}
+
+// Cast a SamplerAddressModeType type to a VkSamplerAddressMode type
+inline VkSamplerAddressMode ToVkSamplerAddressMode(SamplerAddressModeType e) {
+    return static_cast<VkSamplerAddressMode>(e);
+}
+
+// Ensure validity of casted types
+static_assert(sizeof(VkSamplerAddressMode) == sizeof(SamplerAddressModeType));
+
+// Convert a SamplerAddressModeType enum value to cstring name
+inline std::string SamplerAddressModeTypeToName(SamplerAddressModeType e) {
+    switch (static_cast<int>(e)) {
+    case 0:
+        return "VK_SAMPLER_ADDRESS_MODE_REPEAT";
+    case 1:
+        return "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT";
+    case 2:
+        return "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE";
+    case 3:
+        return "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER";
+    case 4:
+        return "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE / VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR";
+    case 0x7FFFFFFF:
+        return "VK_SAMPLER_ADDRESS_MODE_MAX_ENUM";
+    default: {
+        std::stringstream ss;
+        ss << "Unknown(" << e << ")";
+        return ss.str();
+    }
+    }
+}
+
+// Convert a string name to SamplerAddressModeTypeenum value
+inline SamplerAddressModeType NameToSamplerAddressModeType(const std::string &str) {
+    if (str == "VK_SAMPLER_ADDRESS_MODE_REPEAT") {
+        return 0;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT") {
+        return 1;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE") {
+        return 2;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER") {
+        return 3;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE") {
+        return 4;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR") {
+        return 4;
+    }
+    if (str == "VK_SAMPLER_ADDRESS_MODE_MAX_ENUM") {
+        return 0x7FFFFFFF;
+    }
+    // Unknown name
+    return -1;
+}
+
+// Validate that the decoded enum is valid given the Vulkan headers version in use. If this call
+// fails, it indicates that either a newer vulkan_core.h was used by the VGF generator OR that the
+// VGF is corrupted in some other way. Regenerating this header file with a newer Vulkan headers
+// version may resolve the issue.
+inline bool ValidateDecodedSamplerAddressModeType(SamplerAddressModeType e) {
+    switch (static_cast<int>(e)) {
+    case 0:          // VK_SAMPLER_ADDRESS_MODE_REPEAT
+    case 1:          // VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT
+    case 2:          // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
+    case 3:          // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
+    case 4:          // VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE / VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR
+    case 0x7FFFFFFF: // VK_SAMPLER_ADDRESS_MODE_MAX_ENUM
+        return true;
+    default:
+        return false;
+    }
+}
+
+#if defined(VGFLIB_VK_HELPERS)
+using VkBorderColor = int32_t;
+#endif
+
+// Cast a VkBorderColor type to a BorderColorType type
+inline BorderColorType ToBorderColorType(VkBorderColor e) { return static_cast<BorderColorType>(e); }
+
+// Cast a BorderColorType type to a VkBorderColor type
+inline VkBorderColor ToVkBorderColor(BorderColorType e) { return static_cast<VkBorderColor>(e); }
+
+// Ensure validity of casted types
+static_assert(sizeof(VkBorderColor) == sizeof(BorderColorType));
+
+// Convert a BorderColorType enum value to cstring name
+inline std::string BorderColorTypeToName(BorderColorType e) {
+    switch (static_cast<int>(e)) {
+    case 0:
+        return "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK";
+    case 1:
+        return "VK_BORDER_COLOR_INT_TRANSPARENT_BLACK";
+    case 2:
+        return "VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK";
+    case 3:
+        return "VK_BORDER_COLOR_INT_OPAQUE_BLACK";
+    case 4:
+        return "VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE";
+    case 5:
+        return "VK_BORDER_COLOR_INT_OPAQUE_WHITE";
+    case 1000287003:
+        return "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT";
+    case 1000287004:
+        return "VK_BORDER_COLOR_INT_CUSTOM_EXT";
+    case 0x7FFFFFFF:
+        return "VK_BORDER_COLOR_MAX_ENUM";
+    default: {
+        std::stringstream ss;
+        ss << "Unknown(" << e << ")";
+        return ss.str();
+    }
+    }
+}
+
+// Convert a string name to BorderColorTypeenum value
+inline BorderColorType NameToBorderColorType(const std::string &str) {
+    if (str == "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK") {
+        return 0;
+    }
+    if (str == "VK_BORDER_COLOR_INT_TRANSPARENT_BLACK") {
+        return 1;
+    }
+    if (str == "VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK") {
+        return 2;
+    }
+    if (str == "VK_BORDER_COLOR_INT_OPAQUE_BLACK") {
+        return 3;
+    }
+    if (str == "VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE") {
+        return 4;
+    }
+    if (str == "VK_BORDER_COLOR_INT_OPAQUE_WHITE") {
+        return 5;
+    }
+    if (str == "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT") {
+        return 1000287003;
+    }
+    if (str == "VK_BORDER_COLOR_INT_CUSTOM_EXT") {
+        return 1000287004;
+    }
+    if (str == "VK_BORDER_COLOR_MAX_ENUM") {
+        return 0x7FFFFFFF;
+    }
+    // Unknown name
+    return -1;
+}
+
+// Validate that the decoded enum is valid given the Vulkan headers version in use. If this call
+// fails, it indicates that either a newer vulkan_core.h was used by the VGF generator OR that the
+// VGF is corrupted in some other way. Regenerating this header file with a newer Vulkan headers
+// version may resolve the issue.
+inline bool ValidateDecodedBorderColorType(BorderColorType e) {
+    switch (static_cast<int>(e)) {
+    case 0:          // VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK
+    case 1:          // VK_BORDER_COLOR_INT_TRANSPARENT_BLACK
+    case 2:          // VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK
+    case 3:          // VK_BORDER_COLOR_INT_OPAQUE_BLACK
+    case 4:          // VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE
+    case 5:          // VK_BORDER_COLOR_INT_OPAQUE_WHITE
+    case 1000287003: // VK_BORDER_COLOR_FLOAT_CUSTOM_EXT
+    case 1000287004: // VK_BORDER_COLOR_INT_CUSTOM_EXT
+    case 0x7FFFFFFF: // VK_BORDER_COLOR_MAX_ENUM
         return true;
     default:
         return false;

--- a/samples/sample_vulkan.hpp
+++ b/samples/sample_vulkan.hpp
@@ -1,17 +1,21 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
-#define VK_HEADER_VERSION 999
+#include <cstdint>
 
-enum VkDescriptorType {
-    VK_DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000,
-};
+// Samples can build without Vulkan headers by asking the generated helper header
+// to provide int32_t-backed stand-ins for the Vk* enum types it references.
+#define VGFLIB_VK_HELPERS
 
-enum VkFormat {
-    VK_FORMAT_R8_SINT = 14,
-    VK_FORMAT_R32_SINT = 99,
-};
+namespace mlsdk::vgflib::samples {
+
+inline constexpr uint16_t VK_HEADER_VERSION = 999;
+inline constexpr int32_t VK_DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
+inline constexpr int32_t VK_FORMAT_R8_SINT = 14;
+inline constexpr int32_t VK_FORMAT_R32_SINT = 99;
+
+} // namespace mlsdk::vgflib::samples

--- a/schema/vgf.fbs
+++ b/schema/vgf.fbs
@@ -44,6 +44,18 @@ table Description {
     strides: [int64];
 }
 
+table SamplerConfig {
+    min_filter: uint32;
+    mag_filter: uint32;
+    address_mode_u: uint32;
+    address_mode_v: uint32;
+    border_color: uint32;
+}
+
+union ExtraConfig {
+    SamplerConfig
+}
+
 enum ResourceCategory:uint8 {
     INPUT,
     OUTPUT,
@@ -56,6 +68,9 @@ table ModelResourceTableEntry {
     vk_format: uint32; // make the format opaque on disk
     category: ResourceCategory;
     description: Description;
+    // Optional config extension point for resource-specific metadata.
+    // NONE indicates no extra config is present.
+    extra_config: ExtraConfig;
 }
 
 table ModelResourceTable {

--- a/schema/vgf_generated.h
+++ b/schema/vgf_generated.h
@@ -33,6 +33,9 @@ struct ModuleTableBuilder;
 struct Description;
 struct DescriptionBuilder;
 
+struct SamplerConfig;
+struct SamplerConfigBuilder;
+
 struct ModelResourceTableEntry;
 struct ModelResourceTableEntryBuilder;
 
@@ -144,6 +147,47 @@ inline const char *EnumNameModuleType(ModuleType e) {
   const size_t index = static_cast<size_t>(e);
   return EnumNamesModuleType()[index];
 }
+
+enum ExtraConfig : uint8_t {
+  ExtraConfig_NONE = 0,
+  ExtraConfig_SamplerConfig = 1,
+  ExtraConfig_MIN = ExtraConfig_NONE,
+  ExtraConfig_MAX = ExtraConfig_SamplerConfig
+};
+
+inline const ExtraConfig (&EnumValuesExtraConfig())[2] {
+  static const ExtraConfig values[] = {
+    ExtraConfig_NONE,
+    ExtraConfig_SamplerConfig
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesExtraConfig() {
+  static const char * const names[3] = {
+    "NONE",
+    "SamplerConfig",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameExtraConfig(ExtraConfig e) {
+  if (::flatbuffers::IsOutRange(e, ExtraConfig_NONE, ExtraConfig_SamplerConfig)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesExtraConfig()[index];
+}
+
+template<typename T> struct ExtraConfigTraits {
+  static const ExtraConfig enum_value = ExtraConfig_NONE;
+};
+
+template<> struct ExtraConfigTraits<VGF::SamplerConfig> {
+  static const ExtraConfig enum_value = ExtraConfig_SamplerConfig;
+};
+
+bool VerifyExtraConfig(::flatbuffers::Verifier &verifier, const void *obj, ExtraConfig type);
+bool VerifyExtraConfigVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 enum ResourceCategory : uint8_t {
   ResourceCategory_INPUT = 0,
@@ -575,13 +619,96 @@ inline ::flatbuffers::Offset<Description> CreateDescriptionDirect(
       strides__);
 }
 
+struct SamplerConfig FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef SamplerConfigBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_MIN_FILTER = 4,
+    VT_MAG_FILTER = 6,
+    VT_ADDRESS_MODE_U = 8,
+    VT_ADDRESS_MODE_V = 10,
+    VT_BORDER_COLOR = 12
+  };
+  uint32_t min_filter() const {
+    return GetField<uint32_t>(VT_MIN_FILTER, 0);
+  }
+  uint32_t mag_filter() const {
+    return GetField<uint32_t>(VT_MAG_FILTER, 0);
+  }
+  uint32_t address_mode_u() const {
+    return GetField<uint32_t>(VT_ADDRESS_MODE_U, 0);
+  }
+  uint32_t address_mode_v() const {
+    return GetField<uint32_t>(VT_ADDRESS_MODE_V, 0);
+  }
+  uint32_t border_color() const {
+    return GetField<uint32_t>(VT_BORDER_COLOR, 0);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint32_t>(verifier, VT_MIN_FILTER, 4) &&
+           VerifyField<uint32_t>(verifier, VT_MAG_FILTER, 4) &&
+           VerifyField<uint32_t>(verifier, VT_ADDRESS_MODE_U, 4) &&
+           VerifyField<uint32_t>(verifier, VT_ADDRESS_MODE_V, 4) &&
+           VerifyField<uint32_t>(verifier, VT_BORDER_COLOR, 4) &&
+           verifier.EndTable();
+  }
+};
+
+struct SamplerConfigBuilder {
+  typedef SamplerConfig Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_min_filter(uint32_t min_filter) {
+    fbb_.AddElement<uint32_t>(SamplerConfig::VT_MIN_FILTER, min_filter, 0);
+  }
+  void add_mag_filter(uint32_t mag_filter) {
+    fbb_.AddElement<uint32_t>(SamplerConfig::VT_MAG_FILTER, mag_filter, 0);
+  }
+  void add_address_mode_u(uint32_t address_mode_u) {
+    fbb_.AddElement<uint32_t>(SamplerConfig::VT_ADDRESS_MODE_U, address_mode_u, 0);
+  }
+  void add_address_mode_v(uint32_t address_mode_v) {
+    fbb_.AddElement<uint32_t>(SamplerConfig::VT_ADDRESS_MODE_V, address_mode_v, 0);
+  }
+  void add_border_color(uint32_t border_color) {
+    fbb_.AddElement<uint32_t>(SamplerConfig::VT_BORDER_COLOR, border_color, 0);
+  }
+  explicit SamplerConfigBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<SamplerConfig> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<SamplerConfig>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<SamplerConfig> CreateSamplerConfig(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    uint32_t min_filter = 0,
+    uint32_t mag_filter = 0,
+    uint32_t address_mode_u = 0,
+    uint32_t address_mode_v = 0,
+    uint32_t border_color = 0) {
+  SamplerConfigBuilder builder_(_fbb);
+  builder_.add_border_color(border_color);
+  builder_.add_address_mode_v(address_mode_v);
+  builder_.add_address_mode_u(address_mode_u);
+  builder_.add_mag_filter(mag_filter);
+  builder_.add_min_filter(min_filter);
+  return builder_.Finish();
+}
+
 struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef ModelResourceTableEntryBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_VK_DESCRIPTOR_TYPE = 4,
     VT_VK_FORMAT = 6,
     VT_CATEGORY = 8,
-    VT_DESCRIPTION = 10
+    VT_DESCRIPTION = 10,
+    VT_EXTRA_CONFIG_TYPE = 12,
+    VT_EXTRA_CONFIG = 14
   };
   uint32_t vk_descriptor_type() const {
     return GetField<uint32_t>(VT_VK_DESCRIPTOR_TYPE, 0);
@@ -595,6 +722,16 @@ struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   const VGF::Description *description() const {
     return GetPointer<const VGF::Description *>(VT_DESCRIPTION);
   }
+  VGF::ExtraConfig extra_config_type() const {
+    return static_cast<VGF::ExtraConfig>(GetField<uint8_t>(VT_EXTRA_CONFIG_TYPE, 0));
+  }
+  const void *extra_config() const {
+    return GetPointer<const void *>(VT_EXTRA_CONFIG);
+  }
+  template<typename T> const T *extra_config_as() const;
+  const VGF::SamplerConfig *extra_config_as_SamplerConfig() const {
+    return extra_config_type() == VGF::ExtraConfig_SamplerConfig ? static_cast<const VGF::SamplerConfig *>(extra_config()) : nullptr;
+  }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint32_t>(verifier, VT_VK_DESCRIPTOR_TYPE, 4) &&
@@ -602,9 +739,16 @@ struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
            VerifyField<uint8_t>(verifier, VT_CATEGORY, 1) &&
            VerifyOffset(verifier, VT_DESCRIPTION) &&
            verifier.VerifyTable(description()) &&
+           VerifyField<uint8_t>(verifier, VT_EXTRA_CONFIG_TYPE, 1) &&
+           VerifyOffset(verifier, VT_EXTRA_CONFIG) &&
+           VerifyExtraConfig(verifier, extra_config(), extra_config_type()) &&
            verifier.EndTable();
   }
 };
+
+template<> inline const VGF::SamplerConfig *ModelResourceTableEntry::extra_config_as<VGF::SamplerConfig>() const {
+  return extra_config_as_SamplerConfig();
+}
 
 struct ModelResourceTableEntryBuilder {
   typedef ModelResourceTableEntry Table;
@@ -622,6 +766,12 @@ struct ModelResourceTableEntryBuilder {
   void add_description(::flatbuffers::Offset<VGF::Description> description) {
     fbb_.AddOffset(ModelResourceTableEntry::VT_DESCRIPTION, description);
   }
+  void add_extra_config_type(VGF::ExtraConfig extra_config_type) {
+    fbb_.AddElement<uint8_t>(ModelResourceTableEntry::VT_EXTRA_CONFIG_TYPE, static_cast<uint8_t>(extra_config_type), 0);
+  }
+  void add_extra_config(::flatbuffers::Offset<void> extra_config) {
+    fbb_.AddOffset(ModelResourceTableEntry::VT_EXTRA_CONFIG, extra_config);
+  }
   explicit ModelResourceTableEntryBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -638,11 +788,15 @@ inline ::flatbuffers::Offset<ModelResourceTableEntry> CreateModelResourceTableEn
     uint32_t vk_descriptor_type = 0,
     uint32_t vk_format = 0,
     VGF::ResourceCategory category = VGF::ResourceCategory_INPUT,
-    ::flatbuffers::Offset<VGF::Description> description = 0) {
+    ::flatbuffers::Offset<VGF::Description> description = 0,
+    VGF::ExtraConfig extra_config_type = VGF::ExtraConfig_NONE,
+    ::flatbuffers::Offset<void> extra_config = 0) {
   ModelResourceTableEntryBuilder builder_(_fbb);
+  builder_.add_extra_config(extra_config);
   builder_.add_description(description);
   builder_.add_vk_format(vk_format);
   builder_.add_vk_descriptor_type(vk_descriptor_type);
+  builder_.add_extra_config_type(extra_config_type);
   builder_.add_category(category);
   return builder_.Finish();
 }
@@ -1305,6 +1459,31 @@ inline bool VerifyModuleCodeVector(::flatbuffers::Verifier &verifier, const ::fl
   for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
     if (!VerifyModuleCode(
         verifier,  values->Get(i), types->GetEnum<ModuleCode>(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool VerifyExtraConfig(::flatbuffers::Verifier &verifier, const void *obj, ExtraConfig type) {
+  switch (type) {
+    case ExtraConfig_NONE: {
+      return true;
+    }
+    case ExtraConfig_SamplerConfig: {
+      auto ptr = reinterpret_cast<const VGF::SamplerConfig *>(obj);
+      return verifier.VerifyTable(ptr);
+    }
+    default: return true;
+  }
+}
+
+inline bool VerifyExtraConfigVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
+  if (!values || !types) return !values && !types;
+  if (values->size() != types->size()) return false;
+  for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
+    if (!VerifyExtraConfig(
+        verifier,  values->Get(i), types->GetEnum<ExtraConfig>(i))) {
       return false;
     }
   }

--- a/scripts/generate_helpers.py
+++ b/scripts/generate_helpers.py
@@ -49,6 +49,7 @@ def gather_unique_enum_values(vk_name, file_in):
                     name_to_value[name] = value
                 else:
                     value_to_name[name_to_value[str(value)]] += " / " + name
+                    name_to_value[name] = name_to_value[str(value)]
 
     return value_to_name, name_to_value
 
@@ -412,6 +413,13 @@ def main():
             "VkDescriptorType", "DescriptorType", vkHeader
         )
         vkFormatFuncs = generate_enum_code("VkFormat", "FormatType", vkHeader)
+        vkFilterFuncs = generate_enum_code("VkFilter", "FilterType", vkHeader)
+        vkSamplerAddressModeFuncs = generate_enum_code(
+            "VkSamplerAddressMode", "SamplerAddressModeType", vkHeader
+        )
+        vkBorderColorFuncs = generate_enum_code(
+            "VkBorderColor", "BorderColorType", vkHeader
+        )
         with open(args.vulkan_format_traits, "r") as vkFormatTraits:
             with open(args.vulkan_enums, "r") as vkEnums:
                 vkFormatTraitsFunctions = generate_func_for_format_type_traits(
@@ -427,6 +435,9 @@ def main():
                     dst_header.write(vkHeaderVersion)
                     dst_header.write(vkDescriptorTypeFuncs)
                     dst_header.write(vkFormatFuncs)
+                    dst_header.write(vkFilterFuncs)
+                    dst_header.write(vkSamplerAddressModeFuncs)
+                    dst_header.write(vkBorderColorFuncs)
                     dst_header.write(vkFormatTraitsFunctions)
                 else:
                     dst_header.write(src_line)

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -410,6 +410,12 @@ PushConstantRangeHandle ToHandle(const flatbuffers::Vector<flatbuffers::Offset<V
     return reinterpret_cast<PushConstantRangeHandle>(ptr);
 }
 
+const VGF::SamplerConfig *FromHandle(SamplerConfigHandle handle) {
+    return reinterpret_cast<const VGF::SamplerConfig *>(handle);
+}
+
+SamplerConfigHandle ToHandle(const VGF::SamplerConfig *ptr) { return reinterpret_cast<SamplerConfigHandle>(ptr); }
+
 } // namespace
 
 // Model Sequence Table Decoder
@@ -632,7 +638,44 @@ class ModelResourceTableDecoderImpl : public ModelResourceTableDecoder {
         return {strides->data(), strides->size()};
     }
 
+    [[nodiscard]] SamplerConfigHandle getSamplerConfigHandle(uint32_t id) const override {
+        return ToHandle(getSamplerConfigAt(id));
+    }
+
+    [[nodiscard]] uint32_t getSamplerConfigMinFilter(SamplerConfigHandle handle) const override {
+        assert(handle != nullptr && "sampler config handle is null");
+        return FromHandle(handle)->min_filter();
+    }
+
+    [[nodiscard]] uint32_t getSamplerConfigMagFilter(SamplerConfigHandle handle) const override {
+        assert(handle != nullptr && "sampler config handle is null");
+        return FromHandle(handle)->mag_filter();
+    }
+
+    [[nodiscard]] uint32_t getSamplerConfigAddressModeU(SamplerConfigHandle handle) const override {
+        assert(handle != nullptr && "sampler config handle is null");
+        return FromHandle(handle)->address_mode_u();
+    }
+
+    [[nodiscard]] uint32_t getSamplerConfigAddressModeV(SamplerConfigHandle handle) const override {
+        assert(handle != nullptr && "sampler config handle is null");
+        return FromHandle(handle)->address_mode_v();
+    }
+
+    [[nodiscard]] uint32_t getSamplerConfigBorderColor(SamplerConfigHandle handle) const override {
+        assert(handle != nullptr && "sampler config handle is null");
+        return FromHandle(handle)->border_color();
+    }
+
   private:
+    [[nodiscard]] const VGF::SamplerConfig *getSamplerConfigAt(uint32_t index) const {
+        const auto *entry = getEntryAt(index);
+        if (entry->extra_config_type() != VGF::ExtraConfig_SamplerConfig) {
+            return nullptr;
+        }
+        return entry->extra_config_as_SamplerConfig();
+    }
+
     [[nodiscard]] const VGF::ModelResourceTableEntry *getEntryAt(uint32_t index) const {
         const auto *entryTable = modelRecTable_->mrt_entry();
         assert(entryTable && "no entryTable found");

--- a/src/decoder_c_api.cpp
+++ b/src/decoder_c_api.cpp
@@ -150,6 +150,14 @@ mlsdk_vk_format convert_vk_format(FormatType format) {
 
     return static_cast<mlsdk_vk_format>(format);
 }
+
+mlsdk_decoder_sampler_config_handle to_c_handle(SamplerConfigHandle handleIn) {
+    return reinterpret_cast<mlsdk_decoder_sampler_config_handle>(handleIn);
+}
+
+SamplerConfigHandle from_c_handle(mlsdk_decoder_sampler_config_handle handleIn) {
+    return reinterpret_cast<SamplerConfigHandle>(handleIn);
+}
 } // namespace
 
 mlsdk_decoder_module_type mlsdk_decoder_get_module_type(const mlsdk_decoder_module_table_decoder *const decoder,
@@ -589,4 +597,56 @@ void mlsdk_decoder_model_resource_table_get_tensor_strides(
         reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->getTensorStride(mrtIdx);
     dimensions->data = tensorStrides.begin();
     dimensions->size = tensorStrides.size();
+}
+
+mlsdk_decoder_sampler_config_handle mlsdk_decoder_model_resource_table_get_sampler_config_handle(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t mrtIdx) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    return to_c_handle(
+        reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->getSamplerConfigHandle(mrtIdx));
+}
+
+uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_min_filter(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(handle != nullptr && "sampler config handle is null");
+    return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)
+        ->getSamplerConfigMinFilter(from_c_handle(handle));
+}
+
+uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_mag_filter(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(handle != nullptr && "sampler config handle is null");
+    return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)
+        ->getSamplerConfigMagFilter(from_c_handle(handle));
+}
+
+uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_u(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(handle != nullptr && "sampler config handle is null");
+    return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)
+        ->getSamplerConfigAddressModeU(from_c_handle(handle));
+}
+
+uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_v(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(handle != nullptr && "sampler config handle is null");
+    return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)
+        ->getSamplerConfigAddressModeV(from_c_handle(handle));
+}
+
+uint32_t mlsdk_decoder_model_resource_table_sampler_config_get_border_color(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+    mlsdk_decoder_sampler_config_handle handle) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(handle != nullptr && "sampler config handle is null");
+    return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)
+        ->getSamplerConfigBorderColor(from_c_handle(handle));
 }

--- a/src/decoder_py.cpp
+++ b/src/decoder_py.cpp
@@ -456,6 +456,30 @@ class PyModelResourceTableDecoder final : public ModelResourceTableDecoder {
     DataView<int64_t> getTensorStride(uint32_t id) const override {
         PYBIND11_OVERRIDE_PURE(DataView<int64_t>, ModelResourceTableDecoder, getTensorStride, id);
     }
+
+    SamplerConfigHandle getSamplerConfigHandle(uint32_t id) const override {
+        PYBIND11_OVERRIDE_PURE(SamplerConfigHandle, ModelResourceTableDecoder, getSamplerConfigHandle, id);
+    }
+
+    uint32_t getSamplerConfigMinFilter(SamplerConfigHandle handle) const override {
+        PYBIND11_OVERRIDE_PURE(uint32_t, ModelResourceTableDecoder, getSamplerConfigMinFilter, handle);
+    }
+
+    uint32_t getSamplerConfigMagFilter(SamplerConfigHandle handle) const override {
+        PYBIND11_OVERRIDE_PURE(uint32_t, ModelResourceTableDecoder, getSamplerConfigMagFilter, handle);
+    }
+
+    uint32_t getSamplerConfigAddressModeU(SamplerConfigHandle handle) const override {
+        PYBIND11_OVERRIDE_PURE(uint32_t, ModelResourceTableDecoder, getSamplerConfigAddressModeU, handle);
+    }
+
+    uint32_t getSamplerConfigAddressModeV(SamplerConfigHandle handle) const override {
+        PYBIND11_OVERRIDE_PURE(uint32_t, ModelResourceTableDecoder, getSamplerConfigAddressModeV, handle);
+    }
+
+    uint32_t getSamplerConfigBorderColor(SamplerConfigHandle handle) const override {
+        PYBIND11_OVERRIDE_PURE(uint32_t, ModelResourceTableDecoder, getSamplerConfigBorderColor, handle);
+    }
 };
 
 void pyInitModelResourceTableDecoder(py::module m) {
@@ -476,7 +500,16 @@ void pyInitModelResourceTableDecoder(py::module m) {
             [](const ModelResourceTableDecoder &decoder, uint32_t id) {
                 return pyDataView<int64_t>(decoder.getTensorStride(id));
             },
-            py::arg("id"));
+            py::arg("id"))
+        .def("getSamplerConfigHandle", &ModelResourceTableDecoder::getSamplerConfigHandle, py::arg("id"),
+             py::return_value_policy::reference)
+        .def("getSamplerConfigMinFilter", &ModelResourceTableDecoder::getSamplerConfigMinFilter, py::arg("handle"))
+        .def("getSamplerConfigMagFilter", &ModelResourceTableDecoder::getSamplerConfigMagFilter, py::arg("handle"))
+        .def("getSamplerConfigAddressModeU", &ModelResourceTableDecoder::getSamplerConfigAddressModeU,
+             py::arg("handle"))
+        .def("getSamplerConfigAddressModeV", &ModelResourceTableDecoder::getSamplerConfigAddressModeV,
+             py::arg("handle"))
+        .def("getSamplerConfigBorderColor", &ModelResourceTableDecoder::getSamplerConfigBorderColor, py::arg("handle"));
 
     m.def("ModelResourceTableDecoderSize", &ModelResourceTableDecoderSize);
     m.def(
@@ -539,6 +572,7 @@ void pyInitDecoder(py::module m) {
     py::class_<BindingSlotArrayHandle_s>(m, "BindingSlotArrayHandle_s").def(py::init<>());
     py::class_<NameArrayHandle_s>(m, "NameArrayHandle_s").def(py::init<>());
     py::class_<PushConstantRangeHandle_s>(m, "PushConstantRangeHandle_s").def(py::init<>());
+    py::class_<SamplerConfigHandle_s>(m, "SamplerConfigHandle_s");
 
     pyInitHeaderDecoder(m);
     pyInitModuleTableDecoder(m);

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -220,6 +220,7 @@ class EncoderImpl : public Encoder {
             vkFormat,
             shape,
             strides,
+            std::nullopt,
         });
         return {static_cast<uint32_t>(resourceRecords_.size() - 1)};
     }
@@ -243,6 +244,16 @@ class EncoderImpl : public Encoder {
     ResourceRef AddConstantResource(FormatType vkFormat, const std::vector<int64_t> &shape,
                                     const std::vector<int64_t> &strides) override {
         return AddModelResourceTableEntry(ResourceCategory::CONSTANT, std::nullopt, vkFormat, shape, strides);
+    }
+
+    void AddSamplerConfig(ResourceRef resource, uint32_t samplerMinFilter, uint32_t samplerMagFilter,
+                          uint32_t samplerAddressModeU, uint32_t samplerAddressModeV,
+                          uint32_t samplerBorderColor) override {
+        assert(!finished_ && "cannot add sampler config when marked as finished");
+        assert(resource.reference < resourceRecords_.size() && "resource reference out of range");
+        resourceRecords_[resource.reference].samplerConfig = SamplerConfigRecord{
+            samplerMinFilter, samplerMagFilter, samplerAddressModeU, samplerAddressModeV, samplerBorderColor,
+        };
     }
 
     ConstantRef AddConstant(ResourceRef resourceRef, const void *data, size_t sizeInBytes,
@@ -292,9 +303,19 @@ class EncoderImpl : public Encoder {
                                                   : NullOptDescriptorType();
                     auto description =
                         VGF::CreateDescriptionDirect(modelResourceBuilder_, &resource.shape, &resource.strides);
-                    return VGF::CreateModelResourceTableEntry(modelResourceBuilder_, encodedDescType,
-                                                              static_cast<uint32_t>(resource.vkFormat),
-                                                              toVGF(resource.category), description);
+                    VGF::ExtraConfig extraConfigType = VGF::ExtraConfig_NONE;
+                    flatbuffers::Offset<void> extraConfig;
+                    if (resource.samplerConfig.has_value()) {
+                        const SamplerConfigRecord &config = *resource.samplerConfig;
+                        auto samplerConfig =
+                            VGF::CreateSamplerConfig(modelResourceBuilder_, config.minFilter, config.magFilter,
+                                                     config.addressModeU, config.addressModeV, config.borderColor);
+                        extraConfigType = VGF::ExtraConfig_SamplerConfig;
+                        extraConfig = samplerConfig.Union();
+                    }
+                    return VGF::CreateModelResourceTableEntry(
+                        modelResourceBuilder_, encodedDescType, static_cast<uint32_t>(resource.vkFormat),
+                        toVGF(resource.category), description, extraConfigType, extraConfig);
                 });
         auto modelResourceTable = VGF::CreateModelResourceTable(modelResourceBuilder_, modelResourceTableEntries);
         modelResourceBuilder_.Finish(modelResourceTable);
@@ -378,12 +399,21 @@ class EncoderImpl : public Encoder {
     }
 
   private:
+    struct SamplerConfigRecord {
+        uint32_t minFilter;
+        uint32_t magFilter;
+        uint32_t addressModeU;
+        uint32_t addressModeV;
+        uint32_t borderColor;
+    };
+
     struct ResourceRecord {
         ResourceCategory category;
         std::optional<DescriptorType> vkDescriptorType;
         FormatType vkFormat;
         std::vector<int64_t> shape;
         std::vector<int64_t> strides;
+        std::optional<SamplerConfigRecord> samplerConfig;
     };
 
     bool finished_ = false;

--- a/src/encoder_py.cpp
+++ b/src/encoder_py.cpp
@@ -85,6 +85,13 @@ class PyEncoder final : public Encoder {
         PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddConstantResource, vkFormat, shape, strides);
     }
 
+    void AddSamplerConfig(ResourceRef resource, uint32_t samplerMinFilter, uint32_t samplerMagFilter,
+                          uint32_t samplerAddressModeU, uint32_t samplerAddressModeV,
+                          uint32_t samplerBorderColor) override {
+        PYBIND11_OVERRIDE_PURE(void, Encoder, AddSamplerConfig, resource, samplerMinFilter, samplerMagFilter,
+                               samplerAddressModeU, samplerAddressModeV, samplerBorderColor);
+    }
+
     ConstantRef AddConstant(ResourceRef resourceRef, const void *data, size_t sizeInBytes,
                             int64_t sparsityDimension) override {
         PYBIND11_OVERRIDE_PURE(ConstantRef, Encoder, AddConstant, resourceRef, data, sizeInBytes, sparsityDimension);
@@ -156,6 +163,9 @@ void pyInitEncoder(py::module m) {
              py::arg("vkFormat"), py::arg("shape"), py::arg("strides"))
         .def("AddConstantResource", &Encoder::AddConstantResource, py::arg("vkFormat"), py::arg("shape"),
              py::arg("strides"))
+        .def("AddSamplerConfig", &Encoder::AddSamplerConfig, py::arg("resource"), py::arg("samplerMinFilter"),
+             py::arg("samplerMagFilter"), py::arg("samplerAddressModeU"), py::arg("samplerAddressModeV"),
+             py::arg("samplerBorderColor"))
         .def(
             "AddConstant",
             [](Encoder &encoder, ResourceRef resRef, const py::buffer &buffer, int64_t sparsityDimension) {

--- a/test/model_resource_tests.cpp
+++ b/test/model_resource_tests.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -26,6 +27,7 @@ namespace {
 const uint16_t pretendVulkanHeaderVersion = 123;
 
 constexpr DescriptorType VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3;
+constexpr DescriptorType VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1;
 constexpr FormatType VK_FORMAT_R4G4_UNORM_PACK8 = 1;
 constexpr FormatType VK_FORMAT_R4G4B4A4_UNORM_PACK16 = 12;
 
@@ -182,6 +184,51 @@ TEST(CppModelResourceTable, UnknownDimensions) {
     ASSERT_TRUE(mrtDecoder->getDescriptorType(resource1.reference).has_value() == false);
     ASSERT_TRUE(mrtDecoder->getVkFormat(resource1.reference) == VK_FORMAT_R4G4B4A4_UNORM_PACK16);
     ASSERT_TRUE(mrtDecoder->getTensorShape(resource1.reference) == DataView<int64_t>(shape2.data(), shape2.size()));
+}
+
+TEST(CppModelResourceTable, SamplerFieldsRoundTripAndDefaults) {
+    std::stringstream buffer;
+
+    std::unique_ptr<Encoder> encoder = CreateEncoder(pretendVulkanHeaderVersion);
+    std::vector<int64_t> shape{1, 2, 3, 4};
+    std::vector<int64_t> strides{8, 12, 16, 20};
+
+    constexpr uint32_t SAMPLER_MIN_FILTER = 0;     // VK_FILTER_NEAREST
+    constexpr uint32_t SAMPLER_MAG_FILTER = 1;     // VK_FILTER_LINEAR
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_U = 2; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_V = 3; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
+    constexpr uint32_t SAMPLER_BORDER_COLOR = 4;   // VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE
+
+    ResourceRef sampledResource = encoder->AddInputResource(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                            VK_FORMAT_R4G4_UNORM_PACK8, shape, strides);
+    encoder->AddSamplerConfig(sampledResource, SAMPLER_MIN_FILTER, SAMPLER_MAG_FILTER, SAMPLER_ADDRESS_MODE_U,
+                              SAMPLER_ADDRESS_MODE_V, SAMPLER_BORDER_COLOR);
+
+    ResourceRef defaultResource =
+        encoder->AddOutputResource(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_FORMAT_R4G4_UNORM_PACK8, shape, strides);
+
+    encoder->Finish();
+    ASSERT_TRUE(encoder->WriteTo(buffer));
+
+    std::string vgfData = buffer.str();
+    std::unique_ptr<HeaderDecoder> headerDecoder = CreateHeaderDecoder(
+        vgfData.c_str(), static_cast<uint64_t>(HeaderSize()), static_cast<uint64_t>(vgfData.size()));
+    ASSERT_NE(headerDecoder, nullptr);
+
+    std::unique_ptr<ModelResourceTableDecoder> mrtDecoder = CreateModelResourceTableDecoder(
+        vgfData.c_str() + headerDecoder->GetModelResourceTableOffset(), headerDecoder->GetModelResourceTableSize());
+    ASSERT_NE(mrtDecoder, nullptr);
+
+    const SamplerConfigHandle sampledHandle = mrtDecoder->getSamplerConfigHandle(sampledResource.reference);
+    ASSERT_NE(sampledHandle, nullptr);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigMinFilter(sampledHandle), SAMPLER_MIN_FILTER);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigMagFilter(sampledHandle), SAMPLER_MAG_FILTER);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigAddressModeU(sampledHandle), SAMPLER_ADDRESS_MODE_U);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigAddressModeV(sampledHandle), SAMPLER_ADDRESS_MODE_V);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigBorderColor(sampledHandle), SAMPLER_BORDER_COLOR);
+
+    const SamplerConfigHandle defaultHandle = mrtDecoder->getSamplerConfigHandle(defaultResource.reference);
+    EXPECT_EQ(defaultHandle, nullptr);
 }
 
 TEST(CppVerify, ModelResourceSizeWrapRejected) {
@@ -403,6 +450,67 @@ TEST(CModelResourceTable, UnknownDimensions) {
     mlsdk_decoder_model_resource_table_get_tensor_shape(resourceTableDecoder, resource1.reference, &tensorShape2);
     ASSERT_TRUE(DataView<int64_t>(tensorShape2.data, tensorShape2.size) ==
                 DataView<int64_t>(shape2.data(), shape2.size()));
+}
+
+TEST(CModelResourceTable, SamplerFieldsRoundTripAndDefaults) {
+    std::stringstream buffer;
+
+    std::unique_ptr<Encoder> encoder = CreateEncoder(pretendVulkanHeaderVersion);
+    std::vector<int64_t> shape{1, 2, 3, 4};
+    std::vector<int64_t> strides{8, 12, 16, 20};
+
+    constexpr uint32_t SAMPLER_MIN_FILTER = 0;     // VK_FILTER_NEAREST
+    constexpr uint32_t SAMPLER_MAG_FILTER = 1;     // VK_FILTER_LINEAR
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_U = 2; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_V = 3; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
+    constexpr uint32_t SAMPLER_BORDER_COLOR = 4;   // VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE
+
+    auto sampledResource = encoder->AddInputResource(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                     VK_FORMAT_R4G4_UNORM_PACK8, shape, strides);
+    encoder->AddSamplerConfig(sampledResource, SAMPLER_MIN_FILTER, SAMPLER_MAG_FILTER, SAMPLER_ADDRESS_MODE_U,
+                              SAMPLER_ADDRESS_MODE_V, SAMPLER_BORDER_COLOR);
+    auto defaultResource =
+        encoder->AddOutputResource(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_FORMAT_R4G4_UNORM_PACK8, shape, strides);
+
+    encoder->Finish();
+    ASSERT_TRUE(encoder->WriteTo(buffer));
+    std::string data = buffer.str();
+
+    std::vector<uint8_t> headerDecoderMemory;
+    headerDecoderMemory.resize(mlsdk_decoder_header_decoder_mem_reqs());
+    mlsdk_decoder_header_decoder *headerDecoder =
+        mlsdk_decoder_create_header_decoder(data.c_str(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
+                                            static_cast<uint64_t>(data.size()), headerDecoderMemory.data());
+    ASSERT_TRUE(mlsdk_decoder_is_header_valid(headerDecoder));
+    ASSERT_TRUE(mlsdk_decoder_is_header_compatible(headerDecoder));
+
+    mlsdk_decoder_vgf_section_info section;
+    mlsdk_decoder_get_header_section_info(headerDecoder, mlsdk_decoder_section_resources, &section);
+
+    std::vector<uint8_t> resourceTableDecoderMemory;
+    resourceTableDecoderMemory.resize(mlsdk_decoder_model_resource_table_decoder_mem_reqs());
+    mlsdk_decoder_model_resource_table_decoder *resourceTableDecoder =
+        mlsdk_decoder_create_model_resource_table_decoder(data.c_str() + section.offset, section.size,
+                                                          resourceTableDecoderMemory.data());
+    ASSERT_NE(resourceTableDecoder, nullptr);
+
+    mlsdk_decoder_sampler_config_handle sampledHandle =
+        mlsdk_decoder_model_resource_table_get_sampler_config_handle(resourceTableDecoder, sampledResource.reference);
+    ASSERT_NE(sampledHandle, nullptr);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_min_filter(resourceTableDecoder, sampledHandle) ==
+                SAMPLER_MIN_FILTER);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_mag_filter(resourceTableDecoder, sampledHandle) ==
+                SAMPLER_MAG_FILTER);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_u(
+                    resourceTableDecoder, sampledHandle) == SAMPLER_ADDRESS_MODE_U);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_v(
+                    resourceTableDecoder, sampledHandle) == SAMPLER_ADDRESS_MODE_V);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_border_color(
+                    resourceTableDecoder, sampledHandle) == SAMPLER_BORDER_COLOR);
+
+    mlsdk_decoder_sampler_config_handle defaultHandle =
+        mlsdk_decoder_model_resource_table_get_sampler_config_handle(resourceTableDecoder, defaultResource.reference);
+    ASSERT_TRUE(defaultHandle == nullptr);
 }
 
 TEST(CVerify, ModelResourceSizeWrapRejected) {

--- a/test/test_model_resource.py
+++ b/test/test_model_resource.py
@@ -155,3 +155,52 @@ def test_encode_decode_model_resource_table_with_unknown_dimensions():
         mrtDecoder.getVkFormat(resource1.reference) == VK_FORMAT_R4G4B4A4_UNORM_PACK16
     )
     assert mrtDecoder.getTensorStride(resource1.reference) is None
+
+
+def test_encode_decode_model_resource_table_sampler_fields():
+
+    encoder = vgf.CreateEncoder(pretendVulkanHeaderVersion)
+
+    shape = np.array([1, 2, 3, 4], dtype=np.int64)
+    strides = np.array([8, 12, 16, 20], dtype=np.int64)
+
+    VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1
+    VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3
+    VK_FORMAT_R4G4_UNORM_PACK8 = 1
+
+    sampled_resource = encoder.AddInputResource(
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_FORMAT_R4G4_UNORM_PACK8,
+        shape,
+        strides,
+    )
+    encoder.AddSamplerConfig(sampled_resource, 0, 1, 2, 3, 4)
+    default_resource = encoder.AddOutputResource(
+        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_FORMAT_R4G4_UNORM_PACK8, shape, strides
+    )
+
+    encoder.Finish()
+
+    stream = io.BytesIO()
+    assert encoder.WriteTo(stream)
+    buffer = stream.getbuffer()
+
+    headerDecoder = vgf.CreateHeaderDecoder(buffer, vgf.HeaderSize(), buffer.nbytes)
+    assert headerDecoder is not None
+
+    mrtDecoder = vgf.CreateModelResourceTableDecoder(
+        buffer[headerDecoder.GetModelResourceTableOffset() :],
+        headerDecoder.GetModelResourceTableSize(),
+    )
+    assert mrtDecoder is not None
+
+    sampled_handle = mrtDecoder.getSamplerConfigHandle(sampled_resource.reference)
+    assert sampled_handle is not None
+    assert mrtDecoder.getSamplerConfigMinFilter(sampled_handle) == 0
+    assert mrtDecoder.getSamplerConfigMagFilter(sampled_handle) == 1
+    assert mrtDecoder.getSamplerConfigAddressModeU(sampled_handle) == 2
+    assert mrtDecoder.getSamplerConfigAddressModeV(sampled_handle) == 3
+    assert mrtDecoder.getSamplerConfigBorderColor(sampled_handle) == 4
+
+    default_handle = mrtDecoder.getSamplerConfigHandle(default_resource.reference)
+    assert default_handle is None

--- a/utils/src/parse_vgf.cpp
+++ b/utils/src/parse_vgf.cpp
@@ -50,6 +50,25 @@ std::vector<uint32_t> dataViewToVector(DataView<uint32_t> dataView) { return {da
 
 } // namespace
 
+Resource::Resource(uint32_t index, const ModelResourceTableDecoder &decoder)
+    : mIndex(index), mCategory(decoder.getCategory(index)), mDescriptorType(decoder.getDescriptorType(index)),
+      mVkFormat(decoder.getVkFormat(index)) {
+    const SamplerConfigHandle samplerConfigHandle = decoder.getSamplerConfigHandle(index);
+    if (samplerConfigHandle != nullptr) {
+        mSamplerConfig.emplace(decoder.getSamplerConfigMinFilter(samplerConfigHandle),
+                               decoder.getSamplerConfigMagFilter(samplerConfigHandle),
+                               decoder.getSamplerConfigAddressModeU(samplerConfigHandle),
+                               decoder.getSamplerConfigAddressModeV(samplerConfigHandle),
+                               decoder.getSamplerConfigBorderColor(samplerConfigHandle));
+    }
+
+    const auto shape = decoder.getTensorShape(index);
+    mShape.assign(shape.begin(), shape.end());
+
+    const auto stride = decoder.getTensorStride(index);
+    mStride.assign(stride.begin(), stride.end());
+}
+
 std::vector<Resource> parseModelResourceTable(const void *const data, uint64_t size) {
     const auto decoder = CreateModelResourceTableDecoder(data, size);
     if (decoder == nullptr) {
@@ -59,8 +78,7 @@ std::vector<Resource> parseModelResourceTable(const void *const data, uint64_t s
     std::vector<Resource> resources;
     resources.reserve(decoder->size());
     for (uint32_t i = 0; i < decoder->size(); i++) {
-        resources.emplace_back(i, decoder->getCategory(i), decoder->getDescriptorType(i), decoder->getVkFormat(i),
-                               decoder->getTensorShape(i), decoder->getTensorStride(i));
+        resources.emplace_back(i, *decoder);
     }
     return resources;
 }

--- a/utils/src/parse_vgf.hpp
+++ b/utils/src/parse_vgf.hpp
@@ -9,6 +9,7 @@
 #include "vgf/types.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -29,13 +30,23 @@ struct BindingSlot {
     uint32_t mMrtIndex{0};
 };
 
+struct ResourceSamplerConfig {
+    ResourceSamplerConfig() = default;
+    ResourceSamplerConfig(uint32_t minFilter, uint32_t magFilter, uint32_t addressModeU, uint32_t addressModeV,
+                          uint32_t borderColor)
+        : mMinFilter(minFilter), mMagFilter(magFilter), mAddressModeU(addressModeU), mAddressModeV(addressModeV),
+          mBorderColor(borderColor) {}
+
+    uint32_t mMinFilter{0};
+    uint32_t mMagFilter{0};
+    uint32_t mAddressModeU{0};
+    uint32_t mAddressModeV{0};
+    uint32_t mBorderColor{0};
+};
+
 struct Resource {
     Resource() = default;
-    Resource(uint32_t index, mlsdk::vgflib::ResourceCategory category,
-             std::optional<mlsdk::vgflib::DescriptorType> descriptorType, mlsdk::vgflib::VkFormat vkFormat,
-             mlsdk::vgflib::DataView<int64_t> shape, mlsdk::vgflib::DataView<int64_t> stride)
-        : mIndex(index), mCategory(category), mDescriptorType(descriptorType), mVkFormat(vkFormat),
-          mShape(shape.begin(), shape.end()), mStride(stride.begin(), stride.end()) {}
+    Resource(uint32_t index, const mlsdk::vgflib::ModelResourceTableDecoder &decoder);
 
     uint32_t mIndex{0};
     mlsdk::vgflib::ResourceCategory mCategory{mlsdk::vgflib::ResourceCategory::INPUT};
@@ -43,6 +54,7 @@ struct Resource {
     mlsdk::vgflib::FormatType mVkFormat{mlsdk::vgflib::UndefinedFormat()};
     std::vector<int64_t> mShape;
     std::vector<int64_t> mStride;
+    std::optional<ResourceSamplerConfig> mSamplerConfig{std::nullopt};
 };
 
 struct PushConstantRange {

--- a/vgf_dump/src/vgf_dump.cpp
+++ b/vgf_dump/src/vgf_dump.cpp
@@ -389,6 +389,35 @@ void to_json(nlohmann::json &j, const Constant &constant) {
                        {"sparsity_dimension", constant.mSparsityDimension}};
 }
 
+std::string samplerFilterToString(uint32_t value) {
+    if (value > static_cast<uint32_t>(INT32_MAX_VALUE)) {
+        return "Unknown(" + std::to_string(value) + ")";
+    }
+    return FilterTypeToName(static_cast<FilterType>(value));
+}
+
+std::string samplerAddressModeToString(uint32_t value) {
+    if (value > static_cast<uint32_t>(INT32_MAX_VALUE)) {
+        return "Unknown(" + std::to_string(value) + ")";
+    }
+    return SamplerAddressModeTypeToName(static_cast<SamplerAddressModeType>(value));
+}
+
+std::string samplerBorderColorToString(uint32_t value) {
+    if (value > static_cast<uint32_t>(INT32_MAX_VALUE)) {
+        return "Unknown(" + std::to_string(value) + ")";
+    }
+    return BorderColorTypeToName(static_cast<BorderColorType>(value));
+}
+
+void to_json(nlohmann::json &j, const ResourceSamplerConfig &samplerConfig) {
+    j = nlohmann::json{{"min_filter", samplerFilterToString(samplerConfig.mMinFilter)},
+                       {"mag_filter", samplerFilterToString(samplerConfig.mMagFilter)},
+                       {"address_mode_u", samplerAddressModeToString(samplerConfig.mAddressModeU)},
+                       {"address_mode_v", samplerAddressModeToString(samplerConfig.mAddressModeV)},
+                       {"border_color", samplerBorderColorToString(samplerConfig.mBorderColor)}};
+}
+
 void to_json(nlohmann::json &j, const Resource &resource) {
     j = json{
         {"index", resource.mIndex},
@@ -398,6 +427,10 @@ void to_json(nlohmann::json &j, const Resource &resource) {
         {"shape", resource.mShape},
         {"stride", resource.mStride},
     };
+
+    if (resource.mSamplerConfig.has_value()) {
+        j["sampler_config"] = *resource.mSamplerConfig;
+    }
 }
 
 } // namespace vgfutils

--- a/vgf_fuzzer/fuzz_c_decoders.cpp
+++ b/vgf_fuzzer/fuzz_c_decoders.cpp
@@ -98,6 +98,14 @@ void FuzzCDecoderAccessors(const uint8_t *data, size_t size) {
             mlsdk_decoder_tensor_dimensions dims{};
             mlsdk_decoder_model_resource_table_get_tensor_shape(mrtDec, idx, &dims);
             mlsdk_decoder_model_resource_table_get_tensor_strides(mrtDec, idx, &dims);
+            const auto samplerConfigHandle = mlsdk_decoder_model_resource_table_get_sampler_config_handle(mrtDec, idx);
+            if (samplerConfigHandle != nullptr) {
+                mlsdk_decoder_model_resource_table_sampler_config_get_min_filter(mrtDec, samplerConfigHandle);
+                mlsdk_decoder_model_resource_table_sampler_config_get_mag_filter(mrtDec, samplerConfigHandle);
+                mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_u(mrtDec, samplerConfigHandle);
+                mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_v(mrtDec, samplerConfigHandle);
+                mlsdk_decoder_model_resource_table_sampler_config_get_border_color(mrtDec, samplerConfigHandle);
+            }
         }
     }
 

--- a/vgf_fuzzer/fuzz_cpp_decoders.cpp
+++ b/vgf_fuzzer/fuzz_cpp_decoders.cpp
@@ -76,6 +76,14 @@ void FuzzCppDecoderAccessors(const uint8_t *data, size_t size) {
             mrtDec->getCategory(idx);
             mrtDec->getTensorShape(idx);
             mrtDec->getTensorStride(idx);
+            const auto samplerConfigHandle = mrtDec->getSamplerConfigHandle(idx);
+            if (samplerConfigHandle != nullptr) {
+                mrtDec->getSamplerConfigMinFilter(samplerConfigHandle);
+                mrtDec->getSamplerConfigMagFilter(samplerConfigHandle);
+                mrtDec->getSamplerConfigAddressModeU(samplerConfigHandle);
+                mrtDec->getSamplerConfigAddressModeV(samplerConfigHandle);
+                mrtDec->getSamplerConfigBorderColor(samplerConfigHandle);
+            }
         }
     }
 

--- a/vgf_updater/src/vgf_updater.cpp
+++ b/vgf_updater/src/vgf_updater.cpp
@@ -29,25 +29,46 @@ using namespace vgfutils;
 namespace {
 
 ResourceRef encodeResource(const Resource &resource, Encoder &encoder) {
+    auto maybeAddSamplerConfig = [&resource, &encoder](ResourceRef resourceRef) {
+        if (resource.mSamplerConfig.has_value()) {
+            const auto &samplerConfig = *resource.mSamplerConfig;
+            encoder.AddSamplerConfig(resourceRef, samplerConfig.mMinFilter, samplerConfig.mMagFilter,
+                                     samplerConfig.mAddressModeU, samplerConfig.mAddressModeV,
+                                     samplerConfig.mBorderColor);
+        }
+    };
+
     switch (resource.mCategory) {
     case ResourceCategory::INPUT:
         if (!resource.mDescriptorType.has_value()) {
             throw std::runtime_error("Input resource missing descriptor type");
         }
-        return encoder.AddInputResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
-                                        resource.mStride);
+        {
+            const auto resourceRef = encoder.AddInputResource(resource.mDescriptorType.value(), resource.mVkFormat,
+                                                              resource.mShape, resource.mStride);
+            maybeAddSamplerConfig(resourceRef);
+            return resourceRef;
+        }
     case ResourceCategory::OUTPUT:
         if (!resource.mDescriptorType.has_value()) {
             throw std::runtime_error("Output resource missing descriptor type");
         }
-        return encoder.AddOutputResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
-                                         resource.mStride);
+        {
+            const auto resourceRef = encoder.AddOutputResource(resource.mDescriptorType.value(), resource.mVkFormat,
+                                                               resource.mShape, resource.mStride);
+            maybeAddSamplerConfig(resourceRef);
+            return resourceRef;
+        }
     case ResourceCategory::INTERMEDIATE:
         if (!resource.mDescriptorType.has_value()) {
             throw std::runtime_error("Intermediate resource missing descriptor type");
         }
-        return encoder.AddIntermediateResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
-                                               resource.mStride);
+        {
+            const auto resourceRef = encoder.AddIntermediateResource(
+                resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape, resource.mStride);
+            maybeAddSamplerConfig(resourceRef);
+            return resourceRef;
+        }
     case ResourceCategory::CONSTANT:
         return encoder.AddConstantResource(resource.mVkFormat, resource.mShape, resource.mStride);
     }


### PR DESCRIPTION
- add sampler metadata support using a dedicated SamplerConfig table attached to model resources through the ExtraConfig union
- replace inline MRT sampler scalar fields with optional union-backed extra_config payloads
- add encoder API to attach sampler metadata post resource creation: AddSamplerConfig(ResourceRef, ...)
- encode sampler config from staged resource records during Finish()
- decode sampler metadata from extra_config union in C++/C/Python paths
- update updater/tooling and model resource tests for the new sampler flow
- regenerate FlatBuffers schema header for the new schema layout

Change-Id: I7c7dc39c0935ac4a0d9164f2768987de550a53c7