### PR TITLE
Add alias group support to VGF resources

### DIFF
--- a/include-c/vgf/decoder.h
+++ b/include-c/vgf/decoder.h
@@ -82,13 +82,10 @@ typedef enum {
 typedef int32_t mlsdk_vk_descriptor_type;
 
 /**
- * @brief Optional mlsdk_vk_descriptor_type
+ * @brief Type for alias group ids
  *
  */
-typedef struct {
-    mlsdk_vk_descriptor_type value;
-    bool has_value;
-} mlsdk_vk_descriptor_type_optional;
+typedef uint32_t mlsdk_alias_group_id;
 
 /**
  * @brief Carrier type for VkFormat
@@ -782,15 +779,28 @@ MLSDKAPI size_t mlsdk_decoder_get_model_resource_table_num_entries(
     const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder);
 
 /**
- * @brief Returns the vk_descriptor_type of the idx-entry in the model resource table
- * or mlsdk_vk_descriptor_type_none for types with no corresponding descriptor type
+ * @brief Gets the vk_descriptor_type of the idx-entry in the model resource table when present
  *
  * @param modelResourceTableDecoder The pointer to the model resource table decoder
  * @param idx The index for the entry in the model resource table
- * @return The model resource vk_descriptor_type of the entry
+ * @param descriptorType The pointer to receive the model resource vk_descriptor_type of the entry
+ * @return true when the entry has a corresponding descriptor type, false otherwise
  */
-MLSDKAPI mlsdk_vk_descriptor_type_optional mlsdk_decoder_get_vk_descriptor_type(
-    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t idx);
+MLSDKAPI bool
+mlsdk_decoder_get_vk_descriptor_type(const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
+                                     uint32_t idx, mlsdk_vk_descriptor_type *descriptorType);
+
+/**
+ * @brief Returns the alias group id of the idx-entry in the model resource table when present
+ *
+ * @param modelResourceTableDecoder The pointer to the model resource table decoder
+ * @param idx The index for the entry in the model resource table
+ * @param aliasGroupId The pointer to receive the alias group id when present
+ * @return true when the entry shares storage with peer MRT resources, false otherwise
+ */
+MLSDKAPI bool mlsdk_decoder_model_resource_table_get_alias_group_id(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t idx,
+    mlsdk_alias_group_id *aliasGroupId);
 
 /**
  * @brief Returns the vk_format of the idx-entry in the model resource table

--- a/include/vgf/decoder.hpp
+++ b/include/vgf/decoder.hpp
@@ -348,6 +348,13 @@ class ModelResourceTableDecoder {
     virtual std::optional<DescriptorType> getDescriptorType(uint32_t id) const = 0;
 
     /**
+     * @brief Returns the alias group id of the MRT entry 'id' when the entry shares storage with peer MRT entries
+     *
+     * @param id
+     */
+    virtual std::optional<AliasGroupId> getAliasGroupId(uint32_t id) const = 0;
+
+    /**
      * @brief Returns the VkFormat of the MRT entry 'id'
      *
      * @param id

--- a/include/vgf/encoder.hpp
+++ b/include/vgf/encoder.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -89,9 +90,11 @@ class Encoder {
     /// \param vkFormat VkFormat of the resource data
     /// \param shape Vector representation of the resource shape. "-1" values represent an unshaped dimension
     /// \param strides Vector representation of the resource stride. An empty strides is assumed packed layout
+    /// \param aliasGroupId Optional alias group shared with peer MRT entries
     /// \return ResourceRef type containing information for the added table entry
     virtual ResourceRef AddInputResource(DescriptorType descriptorType, FormatType vkFormat,
-                                         const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) = 0;
+                                         const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                         std::optional<AliasGroupId> aliasGroupId = std::nullopt) = 0;
 
     /// \brief Add an OUTPUT resource to the model resource table
     ///
@@ -99,9 +102,11 @@ class Encoder {
     /// \param vkFormat VkFormat of the resource data
     /// \param shape Vector representation of the resource shape. "-1" values represent an unshaped dimension
     /// \param strides Vector representation of the resource stride. An empty strides is assumed packed layout
+    /// \param aliasGroupId Optional alias group shared with peer MRT entries
     /// \return ResourceRef type containing information for the added table entry
     virtual ResourceRef AddOutputResource(DescriptorType descriptorType, FormatType vkFormat,
-                                          const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) = 0;
+                                          const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                          std::optional<AliasGroupId> aliasGroupId = std::nullopt) = 0;
 
     /// \brief Add an INTERMEDIATE resource to the model resource table
     ///
@@ -109,10 +114,11 @@ class Encoder {
     /// \param vkFormat VkFormat of the resource data
     /// \param shape Vector representation of the resource shape. "-1" values represent an unshaped dimension
     /// \param strides Vector representation of the resource stride. An empty strides is assumed packed layout
+    /// \param aliasGroupId Optional alias group shared with peer MRT entries
     /// \return ResourceRef type containing information for the added table entry
     virtual ResourceRef AddIntermediateResource(DescriptorType descriptorType, FormatType vkFormat,
-                                                const std::vector<int64_t> &shape,
-                                                const std::vector<int64_t> &strides) = 0;
+                                                const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                                std::optional<AliasGroupId> aliasGroupId = std::nullopt) = 0;
 
     /// \brief Add a CONSTANT tensor to the model resource table
     ///
@@ -134,6 +140,15 @@ class Encoder {
     virtual void AddSamplerConfig(ResourceRef resource, uint32_t samplerMinFilter, uint32_t samplerMagFilter,
                                   uint32_t samplerAddressModeU, uint32_t samplerAddressModeV,
                                   uint32_t samplerBorderColor) = 0;
+
+    /// \brief Assign an alias group to an existing non-constant MRT entry
+    ///
+    /// \param resource Resource reference used in model resource table
+    /// \param aliasGroupId Alias group shared with peer MRT entries
+    ///
+    /// Reapplying the same alias group is a no-op. Applying a different alias
+    /// group to a resource that already has one is invalid.
+    virtual void SetAliasGroup(ResourceRef resource, AliasGroupId aliasGroupId) = 0;
 
     /// \brief Add constant values to a constant resource type in the model resource table
     ///

--- a/include/vgf/types.hpp
+++ b/include/vgf/types.hpp
@@ -100,6 +100,17 @@ using SamplerAddressModeType = int32_t;
  */
 using BorderColorType = int32_t;
 
+/**
+ * \brief VGF identifier for a symmetric resource alias group.
+ *
+ * Values are encoder-local and multiple MRT entries may share the same alias
+ * group id to indicate shared storage.
+ */
+using AliasGroupId = uint32_t;
+
+/// \brief Reserved alias group id value used as the on-disk "unset" sentinel.
+constexpr AliasGroupId INVALID_ALIAS_GROUP_ID = UINT32_MAX_VALUE;
+
 /// \brief Value that corresponds to an Undefined VkFormat.
 constexpr FormatType UndefinedFormat() { return 0; }
 

--- a/schema/vgf.fbs
+++ b/schema/vgf.fbs
@@ -71,6 +71,9 @@ table ModelResourceTableEntry {
     // Optional config extension point for resource-specific metadata.
     // NONE indicates no extra config is present.
     extra_config: ExtraConfig;
+    // Optional symmetric alias group identifier shared by MRT entries that use
+    // the same storage. When omitted, the MRT entry does not alias peers.
+    alias_group_id: uint = 4294967295;
 }
 
 table ModelResourceTable {

--- a/schema/vgf_generated.h
+++ b/schema/vgf_generated.h
@@ -708,7 +708,8 @@ struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
     VT_CATEGORY = 8,
     VT_DESCRIPTION = 10,
     VT_EXTRA_CONFIG_TYPE = 12,
-    VT_EXTRA_CONFIG = 14
+    VT_EXTRA_CONFIG = 14,
+    VT_ALIAS_GROUP_ID = 16
   };
   uint32_t vk_descriptor_type() const {
     return GetField<uint32_t>(VT_VK_DESCRIPTOR_TYPE, 0);
@@ -732,6 +733,9 @@ struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   const VGF::SamplerConfig *extra_config_as_SamplerConfig() const {
     return extra_config_type() == VGF::ExtraConfig_SamplerConfig ? static_cast<const VGF::SamplerConfig *>(extra_config()) : nullptr;
   }
+  uint32_t alias_group_id() const {
+    return GetField<uint32_t>(VT_ALIAS_GROUP_ID, 4294967295);
+  }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint32_t>(verifier, VT_VK_DESCRIPTOR_TYPE, 4) &&
@@ -742,6 +746,7 @@ struct ModelResourceTableEntry FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
            VerifyField<uint8_t>(verifier, VT_EXTRA_CONFIG_TYPE, 1) &&
            VerifyOffset(verifier, VT_EXTRA_CONFIG) &&
            VerifyExtraConfig(verifier, extra_config(), extra_config_type()) &&
+           VerifyField<uint32_t>(verifier, VT_ALIAS_GROUP_ID, 4) &&
            verifier.EndTable();
   }
 };
@@ -772,6 +777,9 @@ struct ModelResourceTableEntryBuilder {
   void add_extra_config(::flatbuffers::Offset<void> extra_config) {
     fbb_.AddOffset(ModelResourceTableEntry::VT_EXTRA_CONFIG, extra_config);
   }
+  void add_alias_group_id(uint32_t alias_group_id) {
+    fbb_.AddElement<uint32_t>(ModelResourceTableEntry::VT_ALIAS_GROUP_ID, alias_group_id, 4294967295);
+  }
   explicit ModelResourceTableEntryBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -790,8 +798,10 @@ inline ::flatbuffers::Offset<ModelResourceTableEntry> CreateModelResourceTableEn
     VGF::ResourceCategory category = VGF::ResourceCategory_INPUT,
     ::flatbuffers::Offset<VGF::Description> description = 0,
     VGF::ExtraConfig extra_config_type = VGF::ExtraConfig_NONE,
-    ::flatbuffers::Offset<void> extra_config = 0) {
+    ::flatbuffers::Offset<void> extra_config = 0,
+    uint32_t alias_group_id = 4294967295) {
   ModelResourceTableEntryBuilder builder_(_fbb);
+  builder_.add_alias_group_id(alias_group_id);
   builder_.add_extra_config(extra_config);
   builder_.add_description(description);
   builder_.add_vk_format(vk_format);

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -610,6 +610,15 @@ class ModelResourceTableDecoderImpl : public ModelResourceTableDecoder {
         return static_cast<DescriptorType>(decDescType);
     }
 
+    [[nodiscard]] std::optional<AliasGroupId> getAliasGroupId(uint32_t id) const override {
+        const auto *entry = getEntryAt(id);
+        const AliasGroupId aliasGroupId = entry->alias_group_id();
+        if (aliasGroupId == INVALID_ALIAS_GROUP_ID) {
+            return std::nullopt;
+        }
+        return aliasGroupId;
+    }
+
     [[nodiscard]] FormatType getVkFormat(uint32_t id) const override {
         const auto *entry = getEntryAt(id);
         return static_cast<FormatType>(entry->vk_format());

--- a/src/decoder_c_api.cpp
+++ b/src/decoder_c_api.cpp
@@ -134,17 +134,6 @@ mlsdk_decoder_module_type convert_module_type(ModuleType type) {
     }
 }
 
-mlsdk_vk_descriptor_type_optional convert_descriptor_type(std::optional<DescriptorType> type) {
-    mlsdk_vk_descriptor_type_optional descTypeOptional;
-    memset(&descTypeOptional, 0, sizeof(mlsdk_vk_descriptor_type_optional));
-    if (type.has_value()) {
-        descTypeOptional.value = static_cast<mlsdk_vk_descriptor_type>(*type);
-        descTypeOptional.has_value = true;
-    }
-
-    return descTypeOptional;
-}
-
 mlsdk_vk_format convert_vk_format(FormatType format) {
     assert(UndefinedFormat() == mlsdk_vk_format_undefined() && "API vk_format_undefined mismatch");
 
@@ -489,12 +478,36 @@ size_t mlsdk_decoder_get_model_resource_table_num_entries(
     return reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->size();
 }
 
-mlsdk_vk_descriptor_type_optional
-mlsdk_decoder_get_vk_descriptor_type(const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder,
-                                     uint32_t idx) {
+bool mlsdk_decoder_get_vk_descriptor_type(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t idx,
+    mlsdk_vk_descriptor_type *descriptorType) {
     assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
-    return convert_descriptor_type(
-        reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->getDescriptorType(idx));
+    assert(descriptorType != nullptr && "descriptorType is null");
+
+    const std::optional<DescriptorType> type =
+        reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->getDescriptorType(idx);
+    if (!type.has_value()) {
+        return false;
+    }
+
+    *descriptorType = static_cast<mlsdk_vk_descriptor_type>(*type);
+    return true;
+}
+
+bool mlsdk_decoder_model_resource_table_get_alias_group_id(
+    const mlsdk_decoder_model_resource_table_decoder *const modelResourceTableDecoder, uint32_t idx,
+    mlsdk_alias_group_id *aliasGroupId) {
+    assert(modelResourceTableDecoder != nullptr && "modelResourceTableDecoder is null");
+    assert(aliasGroupId != nullptr && "aliasGroupId is null");
+
+    const std::optional<AliasGroupId> value =
+        reinterpret_cast<const ModelResourceTableDecoder *>(modelResourceTableDecoder)->getAliasGroupId(idx);
+    if (!value.has_value()) {
+        return false;
+    }
+
+    *aliasGroupId = *value;
+    return true;
 }
 
 mlsdk_vk_format mlsdk_vk_format_undefined() { return UndefinedFormat(); }

--- a/src/decoder_py.cpp
+++ b/src/decoder_py.cpp
@@ -441,6 +441,10 @@ class PyModelResourceTableDecoder final : public ModelResourceTableDecoder {
         PYBIND11_OVERRIDE_PURE(std::optional<DescriptorType>, ModelResourceTableDecoder, getDescriptorType, id);
     }
 
+    std::optional<AliasGroupId> getAliasGroupId(uint32_t id) const override {
+        PYBIND11_OVERRIDE_PURE(std::optional<AliasGroupId>, ModelResourceTableDecoder, getAliasGroupId, id);
+    }
+
     FormatType getVkFormat(uint32_t id) const override {
         PYBIND11_OVERRIDE_PURE(FormatType, ModelResourceTableDecoder, getVkFormat, id);
     }
@@ -487,6 +491,7 @@ void pyInitModelResourceTableDecoder(py::module m) {
         .def(py::init<>())
         .def("size", &ModelResourceTableDecoder::size)
         .def("getDescriptorType", &ModelResourceTableDecoder::getDescriptorType, py::arg("id"))
+        .def("getAliasGroupId", &ModelResourceTableDecoder::getAliasGroupId, py::arg("id"))
         .def("getVkFormat", &ModelResourceTableDecoder::getVkFormat, py::arg("id"))
         .def("getCategory", &ModelResourceTableDecoder::getCategory, py::arg("id"))
         .def(

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -212,33 +212,42 @@ class EncoderImpl : public Encoder {
 
     ResourceRef AddModelResourceTableEntry(ResourceCategory category, std::optional<DescriptorType> vkDescriptorType,
                                            FormatType vkFormat, const std::vector<int64_t> &shape,
-                                           const std::vector<int64_t> &strides) {
+                                           const std::vector<int64_t> &strides,
+                                           std::optional<AliasGroupId> aliasGroupId = std::nullopt) {
         assert(!finished_ && "cannot add resource when marked as finished");
+        assert((!aliasGroupId.has_value() || *aliasGroupId != INVALID_ALIAS_GROUP_ID) &&
+               "aliasGroupId must not use the reserved invalid value");
         resourceRecords_.emplace_back(ResourceRecord{
             category,
             vkDescriptorType,
             vkFormat,
             shape,
             strides,
+            aliasGroupId,
             std::nullopt,
         });
         return {static_cast<uint32_t>(resourceRecords_.size() - 1)};
     }
 
     ResourceRef AddInputResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                 const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) override {
-        return AddModelResourceTableEntry(ResourceCategory::INPUT, vkDescriptorType, vkFormat, shape, strides);
+                                 const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                 std::optional<AliasGroupId> aliasGroupId) override {
+        return AddModelResourceTableEntry(ResourceCategory::INPUT, vkDescriptorType, vkFormat, shape, strides,
+                                          aliasGroupId);
     }
 
     ResourceRef AddOutputResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                  const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) override {
-        return AddModelResourceTableEntry(ResourceCategory::OUTPUT, vkDescriptorType, vkFormat, shape, strides);
+                                  const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                  std::optional<AliasGroupId> aliasGroupId) override {
+        return AddModelResourceTableEntry(ResourceCategory::OUTPUT, vkDescriptorType, vkFormat, shape, strides,
+                                          aliasGroupId);
     }
 
     ResourceRef AddIntermediateResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                        const std::vector<int64_t> &shape,
-                                        const std::vector<int64_t> &strides) override {
-        return AddModelResourceTableEntry(ResourceCategory::INTERMEDIATE, vkDescriptorType, vkFormat, shape, strides);
+                                        const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                        std::optional<AliasGroupId> aliasGroupId) override {
+        return AddModelResourceTableEntry(ResourceCategory::INTERMEDIATE, vkDescriptorType, vkFormat, shape, strides,
+                                          aliasGroupId);
     }
 
     ResourceRef AddConstantResource(FormatType vkFormat, const std::vector<int64_t> &shape,
@@ -254,6 +263,23 @@ class EncoderImpl : public Encoder {
         resourceRecords_[resource.reference].samplerConfig = SamplerConfigRecord{
             samplerMinFilter, samplerMagFilter, samplerAddressModeU, samplerAddressModeV, samplerBorderColor,
         };
+    }
+
+    void SetAliasGroup(ResourceRef resource, AliasGroupId aliasGroupId) override {
+        assert(!finished_ && "cannot set alias group when marked as finished");
+        assert(resource.reference < resourceRecords_.size() && "resource reference out of range");
+        assert(aliasGroupId != INVALID_ALIAS_GROUP_ID && "aliasGroupId must not use the reserved invalid value");
+
+        auto &resourceRecord = resourceRecords_[resource.reference];
+        assert(resourceRecord.category != ResourceCategory::CONSTANT &&
+               "constant resources do not support alias groups");
+        if (resourceRecord.aliasGroupId.has_value()) {
+            assert(*resourceRecord.aliasGroupId == aliasGroupId &&
+                   "resource already belongs to a different alias group");
+            return;
+        }
+
+        resourceRecord.aliasGroupId = aliasGroupId;
     }
 
     ConstantRef AddConstant(ResourceRef resourceRef, const void *data, size_t sizeInBytes,
@@ -301,10 +327,11 @@ class EncoderImpl : public Encoder {
                     EncodedDescriptorType encodedDescType =
                         resource.vkDescriptorType ? static_cast<EncodedDescriptorType>(*resource.vkDescriptorType)
                                                   : NullOptDescriptorType();
+                    const uint32_t encodedAliasGroupId = resource.aliasGroupId.value_or(INVALID_ALIAS_GROUP_ID);
                     auto description =
                         VGF::CreateDescriptionDirect(modelResourceBuilder_, &resource.shape, &resource.strides);
                     VGF::ExtraConfig extraConfigType = VGF::ExtraConfig_NONE;
-                    flatbuffers::Offset<void> extraConfig;
+                    flatbuffers::Offset<void> extraConfig{};
                     if (resource.samplerConfig.has_value()) {
                         const SamplerConfigRecord &config = *resource.samplerConfig;
                         auto samplerConfig =
@@ -315,7 +342,7 @@ class EncoderImpl : public Encoder {
                     }
                     return VGF::CreateModelResourceTableEntry(
                         modelResourceBuilder_, encodedDescType, static_cast<uint32_t>(resource.vkFormat),
-                        toVGF(resource.category), description, extraConfigType, extraConfig);
+                        toVGF(resource.category), description, extraConfigType, extraConfig, encodedAliasGroupId);
                 });
         auto modelResourceTable = VGF::CreateModelResourceTable(modelResourceBuilder_, modelResourceTableEntries);
         modelResourceBuilder_.Finish(modelResourceTable);
@@ -413,6 +440,7 @@ class EncoderImpl : public Encoder {
         FormatType vkFormat;
         std::vector<int64_t> shape;
         std::vector<int64_t> strides;
+        std::optional<AliasGroupId> aliasGroupId;
         std::optional<SamplerConfigRecord> samplerConfig;
     };
 

--- a/src/encoder_py.cpp
+++ b/src/encoder_py.cpp
@@ -64,20 +64,24 @@ class PyEncoder final : public Encoder {
     }
 
     ResourceRef AddInputResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                 const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) override {
-        PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddInputResource, vkDescriptorType, vkFormat, shape, strides);
+                                 const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                 std::optional<AliasGroupId> aliasGroupId) override {
+        PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddInputResource, vkDescriptorType, vkFormat, shape, strides,
+                               aliasGroupId);
     }
 
     ResourceRef AddOutputResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                  const std::vector<int64_t> &shape, const std::vector<int64_t> &strides) override {
-        PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddOutputResource, vkDescriptorType, vkFormat, shape, strides);
+                                  const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                  std::optional<AliasGroupId> aliasGroupId) override {
+        PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddOutputResource, vkDescriptorType, vkFormat, shape, strides,
+                               aliasGroupId);
     }
 
     ResourceRef AddIntermediateResource(DescriptorType vkDescriptorType, FormatType vkFormat,
-                                        const std::vector<int64_t> &shape,
-                                        const std::vector<int64_t> &strides) override {
+                                        const std::vector<int64_t> &shape, const std::vector<int64_t> &strides,
+                                        std::optional<AliasGroupId> aliasGroupId) override {
         PYBIND11_OVERRIDE_PURE(ResourceRef, Encoder, AddIntermediateResource, vkDescriptorType, vkFormat, shape,
-                               strides);
+                               strides, aliasGroupId);
     }
 
     ResourceRef AddConstantResource(FormatType vkFormat, const std::vector<int64_t> &shape,
@@ -90,6 +94,10 @@ class PyEncoder final : public Encoder {
                           uint32_t samplerBorderColor) override {
         PYBIND11_OVERRIDE_PURE(void, Encoder, AddSamplerConfig, resource, samplerMinFilter, samplerMagFilter,
                                samplerAddressModeU, samplerAddressModeV, samplerBorderColor);
+    }
+
+    void SetAliasGroup(ResourceRef resource, AliasGroupId aliasGroupId) override {
+        PYBIND11_OVERRIDE_PURE(void, Encoder, SetAliasGroup, resource, aliasGroupId);
     }
 
     ConstantRef AddConstant(ResourceRef resourceRef, const void *data, size_t sizeInBytes,
@@ -156,16 +164,17 @@ void pyInitEncoder(py::module m) {
         .def("AddModelSequenceInputsOutputs", &Encoder::AddModelSequenceInputsOutputs, py::arg("inputs") = py::list(),
              py::arg("inputNames") = py::list(), py::arg("outputs") = py::list(), py::arg("outputNames") = py::list())
         .def("AddInputResource", &Encoder::AddInputResource, py::arg("vkDescriptorType"), py::arg("vkFormat"),
-             py::arg("shape"), py::arg("strides"))
+             py::arg("shape"), py::arg("strides"), py::arg("aliasGroupId") = py::none())
         .def("AddOutputResource", &Encoder::AddOutputResource, py::arg("vkDescriptorType"), py::arg("vkFormat"),
-             py::arg("shape"), py::arg("strides"))
+             py::arg("shape"), py::arg("strides"), py::arg("aliasGroupId") = py::none())
         .def("AddIntermediateResource", &Encoder::AddIntermediateResource, py::arg("vkDescriptorType"),
-             py::arg("vkFormat"), py::arg("shape"), py::arg("strides"))
+             py::arg("vkFormat"), py::arg("shape"), py::arg("strides"), py::arg("aliasGroupId") = py::none())
         .def("AddConstantResource", &Encoder::AddConstantResource, py::arg("vkFormat"), py::arg("shape"),
              py::arg("strides"))
         .def("AddSamplerConfig", &Encoder::AddSamplerConfig, py::arg("resource"), py::arg("samplerMinFilter"),
              py::arg("samplerMagFilter"), py::arg("samplerAddressModeU"), py::arg("samplerAddressModeV"),
              py::arg("samplerBorderColor"))
+        .def("SetAliasGroup", &Encoder::SetAliasGroup, py::arg("resource"), py::arg("aliasGroupId"))
         .def(
             "AddConstant",
             [](Encoder &encoder, ResourceRef resRef, const py::buffer &buffer, int64_t sparsityDimension) {

--- a/test/model_resource_tests.cpp
+++ b/test/model_resource_tests.cpp
@@ -231,6 +231,76 @@ TEST(CppModelResourceTable, SamplerFieldsRoundTripAndDefaults) {
     EXPECT_EQ(defaultHandle, nullptr);
 }
 
+TEST(CppModelResourceTable, AliasGroupRoundTripAndLateAssignment) {
+    std::stringstream buffer;
+
+    std::unique_ptr<Encoder> encoder = CreateEncoder(pretendVulkanHeaderVersion);
+    std::vector<int64_t> inputShape{1, 2, 3, 4};
+    std::vector<int64_t> inputStrides{8, 12, 16, 20};
+    std::vector<int64_t> intermediateShape{4, 3, 2, 1};
+    std::vector<int64_t> intermediateStrides{20, 16, 12, 8};
+    constexpr AliasGroupId SHARED_ALIAS_GROUP = 17;
+
+    constexpr uint32_t SAMPLER_MIN_FILTER = 0;     // VK_FILTER_NEAREST
+    constexpr uint32_t SAMPLER_MAG_FILTER = 1;     // VK_FILTER_LINEAR
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_U = 2; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_V = 3; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
+    constexpr uint32_t SAMPLER_BORDER_COLOR = 4;   // VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE
+
+    ResourceRef inputResource =
+        encoder->AddInputResource(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_FORMAT_R4G4_UNORM_PACK8, inputShape,
+                                  inputStrides, SHARED_ALIAS_GROUP);
+    ResourceRef intermediateResource = encoder->AddIntermediateResource(
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_FORMAT_R4G4_UNORM_PACK8, intermediateShape, intermediateStrides);
+    encoder->SetAliasGroup(intermediateResource, SHARED_ALIAS_GROUP);
+    encoder->SetAliasGroup(intermediateResource, SHARED_ALIAS_GROUP);
+    encoder->AddSamplerConfig(intermediateResource, SAMPLER_MIN_FILTER, SAMPLER_MAG_FILTER, SAMPLER_ADDRESS_MODE_U,
+                              SAMPLER_ADDRESS_MODE_V, SAMPLER_BORDER_COLOR);
+    ResourceRef defaultResource =
+        encoder->AddOutputResource(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_FORMAT_R4G4B4A4_UNORM_PACK16, inputShape, {});
+
+    encoder->Finish();
+    ASSERT_TRUE(encoder->WriteTo(buffer));
+
+    std::string vgfData = buffer.str();
+    std::unique_ptr<HeaderDecoder> headerDecoder = CreateHeaderDecoder(
+        vgfData.c_str(), static_cast<uint64_t>(HeaderSize()), static_cast<uint64_t>(vgfData.size()));
+    ASSERT_NE(headerDecoder, nullptr);
+
+    std::unique_ptr<ModelResourceTableDecoder> mrtDecoder = CreateModelResourceTableDecoder(
+        vgfData.c_str() + headerDecoder->GetModelResourceTableOffset(), headerDecoder->GetModelResourceTableSize());
+    ASSERT_NE(mrtDecoder, nullptr);
+
+    const std::optional<AliasGroupId> inputAliasGroupId = mrtDecoder->getAliasGroupId(inputResource.reference);
+    ASSERT_TRUE(inputAliasGroupId.has_value());
+    EXPECT_EQ(inputAliasGroupId.value(), SHARED_ALIAS_GROUP);
+
+    const std::optional<AliasGroupId> intermediateAliasGroupId =
+        mrtDecoder->getAliasGroupId(intermediateResource.reference);
+    ASSERT_TRUE(intermediateAliasGroupId.has_value());
+    EXPECT_EQ(intermediateAliasGroupId.value(), SHARED_ALIAS_GROUP);
+    EXPECT_EQ(mrtDecoder->getCategory(intermediateResource.reference), ResourceCategory::INTERMEDIATE);
+    EXPECT_EQ(mrtDecoder->getDescriptorType(intermediateResource.reference), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+    EXPECT_EQ(mrtDecoder->getVkFormat(intermediateResource.reference), VK_FORMAT_R4G4_UNORM_PACK8);
+    EXPECT_EQ(mrtDecoder->getTensorShape(intermediateResource.reference),
+              DataView<int64_t>(intermediateShape.data(), intermediateShape.size()));
+    EXPECT_EQ(mrtDecoder->getTensorStride(intermediateResource.reference),
+              DataView<int64_t>(intermediateStrides.data(), intermediateStrides.size()));
+
+    const SamplerConfigHandle intermediateHandle = mrtDecoder->getSamplerConfigHandle(intermediateResource.reference);
+    ASSERT_NE(intermediateHandle, nullptr);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigMinFilter(intermediateHandle), SAMPLER_MIN_FILTER);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigMagFilter(intermediateHandle), SAMPLER_MAG_FILTER);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigAddressModeU(intermediateHandle), SAMPLER_ADDRESS_MODE_U);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigAddressModeV(intermediateHandle), SAMPLER_ADDRESS_MODE_V);
+    EXPECT_EQ(mrtDecoder->getSamplerConfigBorderColor(intermediateHandle), SAMPLER_BORDER_COLOR);
+
+    const std::optional<AliasGroupId> defaultAliasGroupId = mrtDecoder->getAliasGroupId(defaultResource.reference);
+    EXPECT_FALSE(defaultAliasGroupId.has_value());
+    const SamplerConfigHandle defaultHandle = mrtDecoder->getSamplerConfigHandle(defaultResource.reference);
+    EXPECT_EQ(defaultHandle, nullptr);
+}
+
 TEST(CppVerify, ModelResourceSizeWrapRejected) {
     Logger logger;
     const uint64_t resourceOffset = 46;
@@ -356,9 +426,10 @@ TEST(CModelResourceTable, EncodeDecode) {
 
     ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_category(resourceTableDecoder, resource0.reference) ==
                 mlsdk_decoder_mrt_category_input);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference).has_value);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference).value ==
-                mlsdkVkDescriptorTypeStorageImage);
+    mlsdk_vk_descriptor_type resource0DescriptorType = 0;
+    ASSERT_TRUE(
+        mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference, &resource0DescriptorType));
+    ASSERT_TRUE(resource0DescriptorType == mlsdkVkDescriptorTypeStorageImage);
     ASSERT_TRUE(mlsdk_decoder_get_vk_format(resourceTableDecoder, resource0.reference) == mlsdkVkFormatR4g4UnormPack8);
 
     mlsdk_decoder_tensor_dimensions tensorShape1;
@@ -373,7 +444,9 @@ TEST(CModelResourceTable, EncodeDecode) {
 
     ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_category(resourceTableDecoder, resource1.reference) ==
                 mlsdk_decoder_mrt_category_constant);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource1.reference).has_value == false);
+    mlsdk_vk_descriptor_type resource1DescriptorType = 0;
+    ASSERT_FALSE(
+        mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource1.reference, &resource1DescriptorType));
     ASSERT_TRUE(mlsdk_decoder_get_vk_format(resourceTableDecoder, resource1.reference) ==
                 mlsdkVkFormatR4g4b4a4UnormPack16);
 
@@ -430,9 +503,10 @@ TEST(CModelResourceTable, UnknownDimensions) {
 
     ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_category(resourceTableDecoder, resource0.reference) ==
                 mlsdk_decoder_mrt_category_input);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference).has_value);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference).value ==
-                mlsdkVkDescriptorTypeStorageImage);
+    mlsdk_vk_descriptor_type resource0DescriptorType = 0;
+    ASSERT_TRUE(
+        mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource0.reference, &resource0DescriptorType));
+    ASSERT_TRUE(resource0DescriptorType == mlsdkVkDescriptorTypeStorageImage);
     ASSERT_TRUE(mlsdk_decoder_get_vk_format(resourceTableDecoder, resource0.reference) == mlsdkVkFormatR4g4UnormPack8);
 
     mlsdk_decoder_tensor_dimensions tensorShape1;
@@ -442,7 +516,9 @@ TEST(CModelResourceTable, UnknownDimensions) {
 
     ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_category(resourceTableDecoder, resource1.reference) ==
                 mlsdk_decoder_mrt_category_constant);
-    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource1.reference).has_value == false);
+    mlsdk_vk_descriptor_type resource1DescriptorType = 0;
+    ASSERT_FALSE(
+        mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, resource1.reference, &resource1DescriptorType));
     ASSERT_TRUE(mlsdk_decoder_get_vk_format(resourceTableDecoder, resource1.reference) ==
                 mlsdkVkFormatR4g4b4a4UnormPack16);
 
@@ -511,6 +587,109 @@ TEST(CModelResourceTable, SamplerFieldsRoundTripAndDefaults) {
     mlsdk_decoder_sampler_config_handle defaultHandle =
         mlsdk_decoder_model_resource_table_get_sampler_config_handle(resourceTableDecoder, defaultResource.reference);
     ASSERT_TRUE(defaultHandle == nullptr);
+}
+
+TEST(CModelResourceTable, AliasGroupRoundTripAndLateAssignment) {
+    std::stringstream buffer;
+
+    std::unique_ptr<Encoder> encoder = CreateEncoder(pretendVulkanHeaderVersion);
+    std::vector<int64_t> inputShape{1, 2, 3, 4};
+    std::vector<int64_t> inputStrides{8, 12, 16, 20};
+    std::vector<int64_t> intermediateShape{4, 3, 2, 1};
+    std::vector<int64_t> intermediateStrides{20, 16, 12, 8};
+    constexpr AliasGroupId SHARED_ALIAS_GROUP = 17;
+
+    constexpr uint32_t SAMPLER_MIN_FILTER = 0;     // VK_FILTER_NEAREST
+    constexpr uint32_t SAMPLER_MAG_FILTER = 1;     // VK_FILTER_LINEAR
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_U = 2; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
+    constexpr uint32_t SAMPLER_ADDRESS_MODE_V = 3; // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
+    constexpr uint32_t SAMPLER_BORDER_COLOR = 4;   // VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE
+
+    auto inputResource =
+        encoder->AddInputResource(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_FORMAT_R4G4_UNORM_PACK8, inputShape,
+                                  inputStrides, SHARED_ALIAS_GROUP);
+    auto intermediateResource = encoder->AddIntermediateResource(
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_FORMAT_R4G4_UNORM_PACK8, intermediateShape, intermediateStrides);
+    encoder->SetAliasGroup(intermediateResource, SHARED_ALIAS_GROUP);
+    encoder->SetAliasGroup(intermediateResource, SHARED_ALIAS_GROUP);
+    encoder->AddSamplerConfig(intermediateResource, SAMPLER_MIN_FILTER, SAMPLER_MAG_FILTER, SAMPLER_ADDRESS_MODE_U,
+                              SAMPLER_ADDRESS_MODE_V, SAMPLER_BORDER_COLOR);
+    auto defaultResource =
+        encoder->AddOutputResource(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_FORMAT_R4G4B4A4_UNORM_PACK16, inputShape, {});
+
+    encoder->Finish();
+    ASSERT_TRUE(encoder->WriteTo(buffer));
+    std::string data = buffer.str();
+
+    std::vector<uint8_t> headerDecoderMemory;
+    headerDecoderMemory.resize(mlsdk_decoder_header_decoder_mem_reqs());
+    mlsdk_decoder_header_decoder *headerDecoder =
+        mlsdk_decoder_create_header_decoder(data.c_str(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
+                                            static_cast<uint64_t>(data.size()), headerDecoderMemory.data());
+    ASSERT_TRUE(mlsdk_decoder_is_header_valid(headerDecoder));
+    ASSERT_TRUE(mlsdk_decoder_is_header_compatible(headerDecoder));
+
+    mlsdk_decoder_vgf_section_info section;
+    mlsdk_decoder_get_header_section_info(headerDecoder, mlsdk_decoder_section_resources, &section);
+
+    std::vector<uint8_t> resourceTableDecoderMemory;
+    resourceTableDecoderMemory.resize(mlsdk_decoder_model_resource_table_decoder_mem_reqs());
+    mlsdk_decoder_model_resource_table_decoder *resourceTableDecoder =
+        mlsdk_decoder_create_model_resource_table_decoder(data.c_str() + section.offset, section.size,
+                                                          resourceTableDecoderMemory.data());
+    ASSERT_NE(resourceTableDecoder, nullptr);
+
+    mlsdk_alias_group_id inputAliasGroupId = 0;
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_alias_group_id(resourceTableDecoder, inputResource.reference,
+                                                                      &inputAliasGroupId));
+    ASSERT_EQ(inputAliasGroupId, SHARED_ALIAS_GROUP);
+
+    mlsdk_alias_group_id intermediateAliasGroupId = 0;
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_alias_group_id(
+        resourceTableDecoder, intermediateResource.reference, &intermediateAliasGroupId));
+    ASSERT_EQ(intermediateAliasGroupId, SHARED_ALIAS_GROUP);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_get_category(resourceTableDecoder, intermediateResource.reference) ==
+                mlsdk_decoder_mrt_category_intermediate);
+    mlsdk_vk_descriptor_type intermediateDescriptorType = 0;
+    ASSERT_TRUE(mlsdk_decoder_get_vk_descriptor_type(resourceTableDecoder, intermediateResource.reference,
+                                                     &intermediateDescriptorType));
+    ASSERT_TRUE(intermediateDescriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+    ASSERT_TRUE(mlsdk_decoder_get_vk_format(resourceTableDecoder, intermediateResource.reference) ==
+                VK_FORMAT_R4G4_UNORM_PACK8);
+
+    mlsdk_decoder_tensor_dimensions decodedIntermediateShape;
+    mlsdk_decoder_model_resource_table_get_tensor_shape(resourceTableDecoder, intermediateResource.reference,
+                                                        &decodedIntermediateShape);
+    ASSERT_TRUE(DataView<int64_t>(decodedIntermediateShape.data, decodedIntermediateShape.size) ==
+                DataView<int64_t>(intermediateShape.data(), intermediateShape.size()));
+
+    mlsdk_decoder_tensor_dimensions decodedIntermediateStride;
+    mlsdk_decoder_model_resource_table_get_tensor_strides(resourceTableDecoder, intermediateResource.reference,
+                                                          &decodedIntermediateStride);
+    ASSERT_TRUE(DataView<int64_t>(decodedIntermediateStride.data, decodedIntermediateStride.size) ==
+                DataView<int64_t>(intermediateStrides.data(), intermediateStrides.size()));
+
+    mlsdk_decoder_sampler_config_handle intermediateHandle =
+        mlsdk_decoder_model_resource_table_get_sampler_config_handle(resourceTableDecoder,
+                                                                     intermediateResource.reference);
+    ASSERT_NE(intermediateHandle, nullptr);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_min_filter(
+                    resourceTableDecoder, intermediateHandle) == SAMPLER_MIN_FILTER);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_mag_filter(
+                    resourceTableDecoder, intermediateHandle) == SAMPLER_MAG_FILTER);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_u(
+                    resourceTableDecoder, intermediateHandle) == SAMPLER_ADDRESS_MODE_U);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_address_mode_v(
+                    resourceTableDecoder, intermediateHandle) == SAMPLER_ADDRESS_MODE_V);
+    ASSERT_TRUE(mlsdk_decoder_model_resource_table_sampler_config_get_border_color(
+                    resourceTableDecoder, intermediateHandle) == SAMPLER_BORDER_COLOR);
+
+    mlsdk_alias_group_id defaultAliasGroupId = 0;
+    ASSERT_FALSE(mlsdk_decoder_model_resource_table_get_alias_group_id(resourceTableDecoder, defaultResource.reference,
+                                                                       &defaultAliasGroupId));
+    mlsdk_decoder_sampler_config_handle defaultHandle =
+        mlsdk_decoder_model_resource_table_get_sampler_config_handle(resourceTableDecoder, defaultResource.reference);
+    ASSERT_EQ(defaultHandle, nullptr);
 }
 
 TEST(CVerify, ModelResourceSizeWrapRejected) {

--- a/test/test_model_resource.py
+++ b/test/test_model_resource.py
@@ -204,3 +204,95 @@ def test_encode_decode_model_resource_table_sampler_fields():
 
     default_handle = mrtDecoder.getSamplerConfigHandle(default_resource.reference)
     assert default_handle is None
+
+
+def test_encode_decode_model_resource_table_alias_group_fields():
+
+    encoder = vgf.CreateEncoder(pretendVulkanHeaderVersion)
+
+    input_shape = np.array([1, 2, 3, 4], dtype=np.int64)
+    input_strides = np.array([8, 12, 16, 20], dtype=np.int64)
+    intermediate_shape = np.array([4, 3, 2, 1], dtype=np.int64)
+    intermediate_strides = np.array([20, 16, 12, 8], dtype=np.int64)
+    SHARED_ALIAS_GROUP = 17
+
+    VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1
+    VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3
+    VK_FORMAT_R4G4_UNORM_PACK8 = 1
+    VK_FORMAT_R4G4B4A4_UNORM_PACK16 = 12
+
+    input_resource = encoder.AddInputResource(
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_FORMAT_R4G4_UNORM_PACK8,
+        input_shape,
+        input_strides,
+        SHARED_ALIAS_GROUP,
+    )
+    intermediate_resource = encoder.AddIntermediateResource(
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_FORMAT_R4G4_UNORM_PACK8,
+        intermediate_shape,
+        intermediate_strides,
+    )
+    encoder.SetAliasGroup(intermediate_resource, SHARED_ALIAS_GROUP)
+    encoder.SetAliasGroup(intermediate_resource, SHARED_ALIAS_GROUP)
+    encoder.AddSamplerConfig(intermediate_resource, 0, 1, 2, 3, 4)
+    default_resource = encoder.AddOutputResource(
+        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+        input_shape,
+        [],
+    )
+
+    encoder.Finish()
+
+    stream = io.BytesIO()
+    assert encoder.WriteTo(stream)
+    buffer = stream.getbuffer()
+
+    headerDecoder = vgf.CreateHeaderDecoder(buffer, vgf.HeaderSize(), buffer.nbytes)
+    assert headerDecoder is not None
+
+    mrtDecoder = vgf.CreateModelResourceTableDecoder(
+        buffer[headerDecoder.GetModelResourceTableOffset() :],
+        headerDecoder.GetModelResourceTableSize(),
+    )
+    assert mrtDecoder is not None
+
+    assert mrtDecoder.getAliasGroupId(input_resource.reference) == SHARED_ALIAS_GROUP
+    assert (
+        mrtDecoder.getAliasGroupId(intermediate_resource.reference)
+        == SHARED_ALIAS_GROUP
+    )
+    assert (
+        mrtDecoder.getCategory(intermediate_resource.reference)
+        == vgf.ResourceCategory.Intermediate
+    )
+    assert (
+        mrtDecoder.getDescriptorType(intermediate_resource.reference)
+        == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+    )
+    assert (
+        mrtDecoder.getVkFormat(intermediate_resource.reference)
+        == VK_FORMAT_R4G4_UNORM_PACK8
+    )
+    assert mrtDecoder.getTensorShape(intermediate_resource.reference) == memoryview(
+        intermediate_shape
+    )
+    assert mrtDecoder.getTensorStride(intermediate_resource.reference) == memoryview(
+        intermediate_strides
+    )
+
+    intermediate_handle = mrtDecoder.getSamplerConfigHandle(
+        intermediate_resource.reference
+    )
+    assert intermediate_handle is not None
+    assert mrtDecoder.getSamplerConfigMinFilter(intermediate_handle) == 0
+    assert mrtDecoder.getSamplerConfigMagFilter(intermediate_handle) == 1
+    assert mrtDecoder.getSamplerConfigAddressModeU(intermediate_handle) == 2
+    assert mrtDecoder.getSamplerConfigAddressModeV(intermediate_handle) == 3
+    assert mrtDecoder.getSamplerConfigBorderColor(intermediate_handle) == 4
+
+    assert mrtDecoder.getAliasGroupId(default_resource.reference) is None
+    default_handle = mrtDecoder.getSamplerConfigHandle(default_resource.reference)
+    assert default_handle is None

--- a/utils/src/parse_vgf.cpp
+++ b/utils/src/parse_vgf.cpp
@@ -52,7 +52,7 @@ std::vector<uint32_t> dataViewToVector(DataView<uint32_t> dataView) { return {da
 
 Resource::Resource(uint32_t index, const ModelResourceTableDecoder &decoder)
     : mIndex(index), mCategory(decoder.getCategory(index)), mDescriptorType(decoder.getDescriptorType(index)),
-      mVkFormat(decoder.getVkFormat(index)) {
+      mVkFormat(decoder.getVkFormat(index)), mAliasGroupId(decoder.getAliasGroupId(index)) {
     const SamplerConfigHandle samplerConfigHandle = decoder.getSamplerConfigHandle(index);
     if (samplerConfigHandle != nullptr) {
         mSamplerConfig.emplace(decoder.getSamplerConfigMinFilter(samplerConfigHandle),

--- a/utils/src/parse_vgf.hpp
+++ b/utils/src/parse_vgf.hpp
@@ -55,6 +55,7 @@ struct Resource {
     std::vector<int64_t> mShape;
     std::vector<int64_t> mStride;
     std::optional<ResourceSamplerConfig> mSamplerConfig{std::nullopt};
+    std::optional<mlsdk::vgflib::AliasGroupId> mAliasGroupId{std::nullopt};
 };
 
 struct PushConstantRange {

--- a/vgf_dump/src/vgf_dump.cpp
+++ b/vgf_dump/src/vgf_dump.cpp
@@ -427,9 +427,11 @@ void to_json(nlohmann::json &j, const Resource &resource) {
         {"shape", resource.mShape},
         {"stride", resource.mStride},
     };
-
     if (resource.mSamplerConfig.has_value()) {
         j["sampler_config"] = *resource.mSamplerConfig;
+    }
+    if (resource.mAliasGroupId.has_value()) {
+        j["alias_group_id"] = *resource.mAliasGroupId;
     }
 }
 

--- a/vgf_fuzzer/fuzz_c_decoders.cpp
+++ b/vgf_fuzzer/fuzz_c_decoders.cpp
@@ -92,7 +92,10 @@ void FuzzCDecoderAccessors(const uint8_t *data, size_t size) {
         const auto count = mlsdk_decoder_get_model_resource_table_num_entries(mrtDec);
         if (count > 0) {
             const auto idx = static_cast<uint32_t>(std::min<size_t>(count - 1, UINT32_MAX));
-            mlsdk_decoder_get_vk_descriptor_type(mrtDec, idx);
+            mlsdk_vk_descriptor_type descriptorType = 0;
+            (void)mlsdk_decoder_get_vk_descriptor_type(mrtDec, idx, &descriptorType);
+            mlsdk_alias_group_id aliasGroupId = 0;
+            (void)mlsdk_decoder_model_resource_table_get_alias_group_id(mrtDec, idx, &aliasGroupId);
             mlsdk_decoder_get_vk_format(mrtDec, idx);
             mlsdk_decoder_model_resource_table_get_category(mrtDec, idx);
             mlsdk_decoder_tensor_dimensions dims{};

--- a/vgf_fuzzer/fuzz_cpp_decoders.cpp
+++ b/vgf_fuzzer/fuzz_cpp_decoders.cpp
@@ -72,6 +72,10 @@ void FuzzCppDecoderAccessors(const uint8_t *data, size_t size) {
         if (count > 0) {
             const auto idx = static_cast<uint32_t>(std::min<size_t>(count - 1, UINT32_MAX));
             mrtDec->getDescriptorType(idx);
+            const auto aliasGroupId = mrtDec->getAliasGroupId(idx);
+            if (aliasGroupId.has_value()) {
+                aliasGroupId.value();
+            }
             mrtDec->getVkFormat(idx);
             mrtDec->getCategory(idx);
             mrtDec->getTensorShape(idx);

--- a/vgf_updater/src/vgf_updater.cpp
+++ b/vgf_updater/src/vgf_updater.cpp
@@ -44,8 +44,9 @@ ResourceRef encodeResource(const Resource &resource, Encoder &encoder) {
             throw std::runtime_error("Input resource missing descriptor type");
         }
         {
-            const auto resourceRef = encoder.AddInputResource(resource.mDescriptorType.value(), resource.mVkFormat,
-                                                              resource.mShape, resource.mStride);
+            const auto resourceRef =
+                encoder.AddInputResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
+                                         resource.mStride, resource.mAliasGroupId);
             maybeAddSamplerConfig(resourceRef);
             return resourceRef;
         }
@@ -54,8 +55,9 @@ ResourceRef encodeResource(const Resource &resource, Encoder &encoder) {
             throw std::runtime_error("Output resource missing descriptor type");
         }
         {
-            const auto resourceRef = encoder.AddOutputResource(resource.mDescriptorType.value(), resource.mVkFormat,
-                                                               resource.mShape, resource.mStride);
+            const auto resourceRef =
+                encoder.AddOutputResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
+                                          resource.mStride, resource.mAliasGroupId);
             maybeAddSamplerConfig(resourceRef);
             return resourceRef;
         }
@@ -64,8 +66,9 @@ ResourceRef encodeResource(const Resource &resource, Encoder &encoder) {
             throw std::runtime_error("Intermediate resource missing descriptor type");
         }
         {
-            const auto resourceRef = encoder.AddIntermediateResource(
-                resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape, resource.mStride);
+            const auto resourceRef =
+                encoder.AddIntermediateResource(resource.mDescriptorType.value(), resource.mVkFormat, resource.mShape,
+                                                resource.mStride, resource.mAliasGroupId);
             maybeAddSamplerConfig(resourceRef);
             return resourceRef;
         }


### PR DESCRIPTION
Add optional alias_group_id metadata to model resource table entries. Allow alias groups to be assigned when creating input, output, and intermediate resources or later via SetAliasGroup. Update the decoder, C and Python bindings, updater, dump, tests, and fuzzer sources to handle alias groups.

Change-Id: I37d8333fa78fd73a040e5dc587b6bb5b8c807285