### PR TITLE
Harden raw constant section handling

### DIFF
--- a/docs/source/decoder_c_api.rst
+++ b/docs/source/decoder_c_api.rst
@@ -87,7 +87,7 @@ The model constants section is the largest section of a VGF file, which contains
    The data in the constant section is stored in raw bytes, there are no endianness checks. The target host and the host where you create the VGF must use the same endianness.
 
 To retrieve the number of constants in a VGF file, using a constants table decoder, you can use ``mlsdk_decoder_get_constant_table_num_entries``.
-To retrieve constant information through a module table decoder, you can use the following functions:
+To retrieve constant information through a constants table decoder, you can use the following functions:
 
     * **MRT index**: ``mlsdk_decoder_get_constant_table_mrt_index``
     * **Data**: ``mlsdk_decoder_get_constant_table_data``

--- a/docs/source/file_format.rst
+++ b/docs/source/file_format.rst
@@ -1,0 +1,67 @@
+VGF File Format Notes
+=====================
+
+Model Constants Section
+-----------------------
+
+New VGF files store the Model Constants Section as a compact raw byte section. Older files can still contain the
+legacy FlatBuffers ``ConstantSection`` layout; the decoder keeps support for that legacy representation.
+
+The current raw constants layout is version ``CONST00``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Offset
+     - Size
+     - Field
+     - Description
+   * - 0
+     - 8
+     - ``version``
+     - Fixed bytes ``C O N S T 0 0 \0``.
+   * - 8
+     - 8
+     - ``count``
+     - Number of constant metadata records.
+   * - 16
+     - ``count * 24``
+     - ``metadata``
+     - Fixed-size ``ConstantMetaDataV00`` records.
+   * - ``16 + count * 24``
+     - remaining bytes
+     - ``payload``
+     - Raw constant data bytes.
+
+Each ``ConstantMetaDataV00`` record is 24 bytes:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Offset
+     - Size
+     - Field
+     - Description
+   * - 0
+     - 4
+     - ``mrt_index``
+     - Model Resource Table index for the constant resource.
+   * - 4
+     - 4
+     - ``sparsity_dimension``
+     - Sparse dimension, or ``-1`` for a non-sparse constant. Values below ``-1`` are invalid.
+   * - 8
+     - 8
+     - ``size``
+     - Constant data size in bytes, excluding any padding.
+   * - 16
+     - 8
+     - ``offset``
+     - Offset in bytes from the start of the payload region.
+
+Constant payload entries are stored as raw bytes. The encoder pads each payload entry to an 8-byte boundary, but
+``size`` always describes the unpadded constant data length returned by the decoder.
+
+.. caution::
+   The raw constants section stores fixed-width integer fields and payload bytes without endian conversion. The target
+   host and the host that created the VGF file must use the same endianness.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ ML SDK VGF Library
    decoder_c_api.rst
    logging_api.rst
    logging_c_api.rst
+   file_format.rst
    vgf_dump.rst
    vgf_updater.rst
    license.rst

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -9,11 +9,13 @@
 #include "header.hpp"
 #include "internal_logging.hpp"
 #include "internal_types.hpp"
+#include "utils.hpp"
 #include "vgf_generated.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <limits>
 #include <optional>
 #include <tuple>
@@ -150,6 +152,10 @@ template <class T> bool VerifyImpl(const void *data, const uint64_t size) {
 
 const char *getConstantSectionVersion(const void *data) {
     return static_cast<const char *>(data) + CONSTANT_SECTION_VERSION_OFFSET;
+}
+
+bool hasConstantSectionVersion(const void *data) {
+    return std::memcmp(getConstantSectionVersion(data), CONSTANT_SECTION_VERSION, CONSTANT_SECTION_VERSION_SIZE) == 0;
 }
 
 } // namespace
@@ -843,17 +849,23 @@ class ConstantDecoderV00Impl : public ConstantDecoder {
             return std::nullopt;
         }
 
-        const uint64_t dataOffset = CONSTANT_SECTION_METADATA_OFFSET + declaredCount * sizeof(ConstantMetaDataV00);
+        const auto metadataBytes = checkedMul(declaredCount, sizeof(ConstantMetaDataV00));
+        const auto dataOffset = metadataBytes.has_value() ? checkedAdd(CONSTANT_SECTION_METADATA_OFFSET, *metadataBytes)
+                                                          : std::optional<uint64_t>{};
+        if (!dataOffset.has_value()) {
+            logging::error("VerifyConstant: Constant data offset exceeds addressable size");
+            return std::nullopt;
+        }
 #if SIZE_MAX < UINT64_MAX
-        if (dataOffset > SIZE_MAX_VALUE) {
+        if (*dataOffset > SIZE_MAX_VALUE) {
             logging::error("VerifyConstant: Constant data offset exceeds addressable size");
             return std::nullopt;
         }
 #endif
 
         const auto *metaData = static_cast<const uint8_t *>(data) + CONSTANT_SECTION_METADATA_OFFSET;
-        const auto *dataStart = static_cast<const uint8_t *>(data) + static_cast<size_t>(dataOffset);
-        const uint64_t dataSize = sectionSize - dataOffset;
+        const auto *dataStart = static_cast<const uint8_t *>(data) + static_cast<size_t>(*dataOffset);
+        const uint64_t dataSize = sectionSize - *dataOffset;
 
         for (uint64_t idx = 0; idx < declaredCount; ++idx) {
             const auto *entry =
@@ -893,10 +905,7 @@ class ConstantDecoderV00Impl : public ConstantDecoder {
         }
 #endif
 
-        if (offset > dataSize || entrySize > dataSize || entrySize > dataSize - offset) {
-            return false;
-        }
-        return true;
+        return byteRangeWithinBounds({offset, entrySize}, dataSize);
     }
 
     uint64_t count_ = 0;
@@ -913,7 +922,7 @@ std::unique_ptr<ConstantDecoder> CreateConstantDecoder(const void *const data, c
         return nullptr;
     }
     std::unique_ptr<ConstantDecoder> decoder;
-    if (strcmp(getConstantSectionVersion(data), CONSTANT_SECTION_VERSION) == 0) {
+    if (hasConstantSectionVersion(data)) {
         // V00 constant section
         decoder = ConstantDecoderV00Impl::Create(data, size);
         if (decoder == nullptr) {
@@ -945,7 +954,7 @@ ConstantDecoder *CreateConstantDecoderInPlace(const void *const data, const uint
         logging::error("Constant section too small to contain version");
         return nullptr;
     }
-    if (strcmp(getConstantSectionVersion(data), CONSTANT_SECTION_VERSION) == 0) {
+    if (hasConstantSectionVersion(data)) {
         // V00 constant section
         auto *decoder = ConstantDecoderV00Impl::CreateInPlace(data, size, decoderMem);
         if (decoder == nullptr) {

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -10,9 +10,11 @@
 #include "internal_logging.hpp"
 #include "internal_types.hpp"
 #include "section_index_table.hpp"
+#include "utils.hpp"
 #include "vgf_generated.h"
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <limits>
 
@@ -59,8 +61,6 @@ VGF::ResourceCategory toVGF(ResourceCategory category) {
         return VGF::ResourceCategory::ResourceCategory_MAX;
     }
 }
-
-template <typename T> size_t getAlignedSize(size_t size) { return (size + sizeof(T) - 1) / sizeof(T) * sizeof(T); }
 
 } // namespace
 
@@ -299,6 +299,24 @@ class EncoderImpl : public Encoder {
             sparsityDim32 = static_cast<int32_t>(sparsityDimension);
         }
 
+        const auto sizeInBytesAligned = checkedAlignUp(static_cast<uint64_t>(sizeInBytes), sizeof(uint64_t));
+        if (!sizeInBytesAligned.has_value()) {
+            logging::error("Constant size exceeds addressable on-disk metadata size");
+            encodingFailed_ = true;
+            return {UINT32_MAX_VALUE};
+        }
+        if (*sizeInBytesAligned > SIZE_MAX_VALUE) {
+            logging::error("Constant size exceeds addressable host allocation size");
+            encodingFailed_ = true;
+            return {UINT32_MAX_VALUE};
+        }
+        const auto nextDataOffset = checkedAdd(constDataOffset_, *sizeInBytesAligned);
+        if (!nextDataOffset.has_value()) {
+            logging::error("Constant data section size exceeds addressable on-disk metadata size");
+            encodingFailed_ = true;
+            return {UINT32_MAX_VALUE};
+        }
+
         constsMetaData_.emplace_back(ConstantMetaDataV00{
             resourceRef.reference,
             sparsityDim32,
@@ -306,10 +324,9 @@ class EncoderImpl : public Encoder {
             constDataOffset_,
         });
 
-        uint64_t sizeInBytesAligned = getAlignedSize<uint64_t>(sizeInBytes);
-        auto &constantData = constsData_.emplace_back(sizeInBytesAligned, 0);
+        auto &constantData = constsData_.emplace_back(static_cast<size_t>(*sizeInBytesAligned), 0);
         std::memcpy(constantData.data(), data, sizeInBytes);
-        constDataOffset_ += sizeInBytesAligned;
+        constDataOffset_ = *nextDataOffset;
 
         return {static_cast<uint32_t>(constsMetaData_.size() - 1)};
     }
@@ -371,6 +388,10 @@ class EncoderImpl : public Encoder {
     bool WriteTo(std::ostream &output) override {
         assert(finished_ && "cannot write if encoding is not marked finished");
         logging::debug("Writing VGF model to output stream");
+        if (encodingFailed_) {
+            logging::error("Cannot write VGF model after encoder failed");
+            return false;
+        }
 
         SectionIndexTable table;
         const auto &headerSection = table.AddSection(sizeof(Header));
@@ -379,9 +400,18 @@ class EncoderImpl : public Encoder {
         const auto &modelResourceSection = table.AddSection(modelResourceBuilder_.GetSize());
 
         auto numConsts = static_cast<uint64_t>(constsMetaData_.size());
-        const auto constantSectionSize =
-            CONSTANT_SECTION_METADATA_OFFSET + numConsts * sizeof(ConstantMetaDataV00) + constDataOffset_;
-        const auto &constantSection = table.AddSection(constantSectionSize);
+        const auto constantMetadataSize = checkedMul(numConsts, sizeof(ConstantMetaDataV00));
+        const auto constantHeaderAndMetadataSize =
+            constantMetadataSize.has_value() ? checkedAdd(CONSTANT_SECTION_METADATA_OFFSET, *constantMetadataSize)
+                                             : std::optional<uint64_t>{};
+        const auto constantSectionSize = constantHeaderAndMetadataSize.has_value()
+                                             ? checkedAdd(*constantHeaderAndMetadataSize, constDataOffset_)
+                                             : std::optional<uint64_t>{};
+        if (!constantSectionSize.has_value()) {
+            logging::error("Constant section size exceeds addressable on-disk metadata size");
+            return false;
+        }
+        const auto &constantSection = table.AddSection(*constantSectionSize);
 
         // calculate alignments and offsets
         table.Update();
@@ -445,6 +475,7 @@ class EncoderImpl : public Encoder {
     };
 
     bool finished_ = false;
+    bool encodingFailed_ = false;
     flatbuffers::FlatBufferBuilder moduleBuilder_;
     flatbuffers::FlatBufferBuilder modelSequenceBuilder_;
     flatbuffers::FlatBufferBuilder modelResourceBuilder_;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace mlsdk::vgflib {
+
+struct ByteRange {
+    uint64_t offset{};
+    uint64_t size{};
+};
+
+inline std::optional<uint64_t> checkedAdd(uint64_t lhs, uint64_t rhs) {
+    if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
+        return std::nullopt;
+    }
+    return lhs + rhs;
+}
+
+inline std::optional<uint64_t> checkedMul(uint64_t lhs, uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return std::nullopt;
+    }
+    return lhs * rhs;
+}
+
+inline std::optional<uint64_t> checkedAlignUp(uint64_t size, uint64_t alignment) {
+    if (alignment == 0) {
+        return std::nullopt;
+    }
+
+    const auto rounded = checkedAdd(size, alignment - 1);
+    if (!rounded.has_value()) {
+        return std::nullopt;
+    }
+    return (*rounded / alignment) * alignment;
+}
+
+inline bool byteRangeWithinBounds(ByteRange range, uint64_t payloadSize) {
+    if (range.offset > payloadSize) {
+        return false;
+    }
+    return range.size <= payloadSize - range.offset;
+}
+
+} // namespace mlsdk::vgflib


### PR DESCRIPTION
Add shared helpers for checked binary-section arithmetic and byte-range validation, then use them in the raw constant section encoder and decoder.

Replace fixed constant-section version detection with a bounded memcmp, check constant metadata/data size calculations for overflow, and fail encoding cleanly if constant payload sizing can no longer be represented safely.

Document the raw constants section layout, including version bytes, metadata fields, payload layout, padding behavior, and endian assumptions.