### PR TITLE
Refactor binary section range handling

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -798,7 +798,8 @@ class ConstantDecoderV00Impl : public ConstantDecoder {
             return {};
         }
 
-        return DataView<uint8_t>(data_ + metaData->offset, static_cast<size_t>(metaData->size));
+        const ByteRange range = _constantDataRange(*metaData);
+        return DataView<uint8_t>(data_ + static_cast<size_t>(range.offset), static_cast<size_t>(range.size));
     }
 
     [[nodiscard]] uint32_t getConstantMrtIndex(uint32_t idx) const override {
@@ -849,23 +850,16 @@ class ConstantDecoderV00Impl : public ConstantDecoder {
             return std::nullopt;
         }
 
-        const auto metadataBytes = checkedMul(declaredCount, sizeof(ConstantMetaDataV00));
-        const auto dataOffset = metadataBytes.has_value() ? checkedAdd(CONSTANT_SECTION_METADATA_OFFSET, *metadataBytes)
-                                                          : std::optional<uint64_t>{};
-        if (!dataOffset.has_value()) {
+        const auto layout = splitFixedRecordTable(sectionSize, CONSTANT_SECTION_METADATA_OFFSET,
+                                                  sizeof(ConstantMetaDataV00), declaredCount);
+        if (!layout.has_value()) {
             logging::error("VerifyConstant: Constant data offset exceeds addressable size");
             return std::nullopt;
         }
-#if SIZE_MAX < UINT64_MAX
-        if (*dataOffset > SIZE_MAX_VALUE) {
-            logging::error("VerifyConstant: Constant data offset exceeds addressable size");
-            return std::nullopt;
-        }
-#endif
 
-        const auto *metaData = static_cast<const uint8_t *>(data) + CONSTANT_SECTION_METADATA_OFFSET;
-        const auto *dataStart = static_cast<const uint8_t *>(data) + static_cast<size_t>(*dataOffset);
-        const uint64_t dataSize = sectionSize - *dataOffset;
+        const auto *metaData = static_cast<const uint8_t *>(data) + static_cast<size_t>(layout->records.offset);
+        const auto *dataStart = static_cast<const uint8_t *>(data) + static_cast<size_t>(layout->payload.offset);
+        const uint64_t dataSize = layout->payload.size;
 
         for (uint64_t idx = 0; idx < declaredCount; ++idx) {
             const auto *entry =
@@ -892,20 +886,16 @@ class ConstantDecoderV00Impl : public ConstantDecoder {
         return reinterpret_cast<const ConstantMetaDataV00 *>(metaData_ + idx * sizeof(ConstantMetaDataV00));
     }
 
+    [[nodiscard]] static ByteRange _constantDataRange(const ConstantMetaDataV00 &metaData) {
+        return {metaData.offset, metaData.size};
+    }
+
     [[nodiscard]] static bool _constantDataWithinBounds(const ConstantMetaDataV00 *metaData, uint64_t dataSize) {
         if (metaData == nullptr) {
             return false;
         }
-        const uint64_t offset = metaData->offset;
-        const uint64_t entrySize = metaData->size;
-#if SIZE_MAX < UINT64_MAX
-        const uint64_t sizeMax = SIZE_MAX_VALUE;
-        if (offset > sizeMax || entrySize > sizeMax || entrySize > sizeMax - offset) {
-            return false;
-        }
-#endif
-
-        return byteRangeWithinBounds({offset, entrySize}, dataSize);
+        const ByteRange range = _constantDataRange(*metaData);
+        return byteRangeCanBeAddressed(range) && byteRangeWithinBounds(range, dataSize);
     }
 
     uint64_t count_ = 0;

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <fstream>
 #include <limits>
+#include <list>
 
 namespace mlsdk::vgflib {
 
@@ -299,34 +300,26 @@ class EncoderImpl : public Encoder {
             sparsityDim32 = static_cast<int32_t>(sparsityDimension);
         }
 
-        const auto sizeInBytesAligned = checkedAlignUp(static_cast<uint64_t>(sizeInBytes), sizeof(uint64_t));
-        if (!sizeInBytesAligned.has_value()) {
-            logging::error("Constant size exceeds addressable on-disk metadata size");
-            encodingFailed_ = true;
-            return {UINT32_MAX_VALUE};
-        }
-        if (*sizeInBytesAligned > SIZE_MAX_VALUE) {
-            logging::error("Constant size exceeds addressable host allocation size");
-            encodingFailed_ = true;
-            return {UINT32_MAX_VALUE};
-        }
-        const auto nextDataOffset = checkedAdd(constDataOffset_, *sizeInBytesAligned);
-        if (!nextDataOffset.has_value()) {
+        uint64_t nextDataOffset = constDataOffset_;
+        const auto constantDataRange =
+            appendAlignedByteRange(static_cast<uint64_t>(sizeInBytes), sizeof(uint64_t), nextDataOffset);
+        if (!constantDataRange.has_value()) {
             logging::error("Constant data section size exceeds addressable on-disk metadata size");
             encodingFailed_ = true;
             return {UINT32_MAX_VALUE};
         }
+        const auto &[dataRange, paddedSize] = *constantDataRange;
 
         constsMetaData_.emplace_back(ConstantMetaDataV00{
             resourceRef.reference,
             sparsityDim32,
-            sizeInBytes,
-            constDataOffset_,
+            dataRange.size,
+            dataRange.offset,
         });
 
-        auto &constantData = constsData_.emplace_back(static_cast<size_t>(*sizeInBytesAligned), 0);
+        auto &constantData = constsData_.emplace_back(static_cast<size_t>(paddedSize), 0);
         std::memcpy(constantData.data(), data, sizeInBytes);
-        constDataOffset_ = *nextDataOffset;
+        constDataOffset_ = nextDataOffset;
 
         return {static_cast<uint32_t>(constsMetaData_.size() - 1)};
     }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <utility>
 
 namespace mlsdk::vgflib {
 
@@ -16,21 +18,28 @@ struct ByteRange {
     uint64_t size{};
 };
 
-inline std::optional<uint64_t> checkedAdd(uint64_t lhs, uint64_t rhs) {
+using PaddedByteRange = std::pair<ByteRange, uint64_t /* padding */>;
+
+struct FixedRecordTableLayout {
+    ByteRange records{};
+    ByteRange payload{};
+};
+
+constexpr std::optional<uint64_t> checkedAdd(uint64_t lhs, uint64_t rhs) {
     if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
         return std::nullopt;
     }
     return lhs + rhs;
 }
 
-inline std::optional<uint64_t> checkedMul(uint64_t lhs, uint64_t rhs) {
+constexpr std::optional<uint64_t> checkedMul(uint64_t lhs, uint64_t rhs) {
     if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
         return std::nullopt;
     }
     return lhs * rhs;
 }
 
-inline std::optional<uint64_t> checkedAlignUp(uint64_t size, uint64_t alignment) {
+constexpr std::optional<uint64_t> checkedAlignUp(uint64_t size, uint64_t alignment) {
     if (alignment == 0) {
         return std::nullopt;
     }
@@ -42,11 +51,74 @@ inline std::optional<uint64_t> checkedAlignUp(uint64_t size, uint64_t alignment)
     return (*rounded / alignment) * alignment;
 }
 
-inline bool byteRangeWithinBounds(ByteRange range, uint64_t payloadSize) {
+constexpr bool byteRangeWithinBounds(ByteRange range, uint64_t payloadSize) {
     if (range.offset > payloadSize) {
         return false;
     }
     return range.size <= payloadSize - range.offset;
+}
+
+constexpr bool byteRangeCanBeAddressed(ByteRange range) {
+#if SIZE_MAX < UINT64_MAX
+    constexpr uint64_t sizeMax = static_cast<uint64_t>(std::numeric_limits<size_t>::max());
+    if (range.offset > sizeMax || range.size > sizeMax) {
+        return false;
+    }
+    return range.size <= sizeMax - range.offset;
+#else
+    (void)range;
+    return true;
+#endif
+}
+
+// Split a raw section into a fixed-size record table followed by a payload area.
+// Used by raw section decoders to validate that the declared record count fits
+// in the section and to compute the byte ranges for metadata records and
+// variable-size payload data.
+constexpr std::optional<FixedRecordTableLayout> splitFixedRecordTable(uint64_t sectionSize, uint64_t recordsOffset,
+                                                                      uint64_t recordSize, uint64_t recordCount) {
+    if (recordSize == 0 || recordsOffset > sectionSize) {
+        return std::nullopt;
+    }
+
+    const uint64_t maxRecords = (sectionSize - recordsOffset) / recordSize;
+    if (recordCount > maxRecords) {
+        return std::nullopt;
+    }
+
+    const auto recordsSize = checkedMul(recordCount, recordSize);
+    const auto payloadOffset =
+        recordsSize.has_value() ? checkedAdd(recordsOffset, *recordsSize) : std::optional<uint64_t>{};
+    if (!payloadOffset.has_value() || *payloadOffset > sectionSize) {
+        return std::nullopt;
+    }
+
+    FixedRecordTableLayout layout{{recordsOffset, *recordsSize}, {*payloadOffset, sectionSize - *payloadOffset}};
+    if (!byteRangeCanBeAddressed(layout.records) || !byteRangeCanBeAddressed(layout.payload)) {
+        return std::nullopt;
+    }
+
+    return layout;
+}
+
+// Reserve a payload entry whose start is the current payload end and whose
+// storage is padded up to the requested alignment. Used by raw section encoders
+// to record the unpadded byte range in metadata while advancing the payload size
+// by the padded storage size.
+constexpr std::optional<PaddedByteRange> appendAlignedByteRange(uint64_t size, uint64_t alignment,
+                                                                uint64_t &payloadSize) {
+    const auto paddedSize = checkedAlignUp(size, alignment);
+    if (!paddedSize.has_value()) {
+        return std::nullopt;
+    }
+    const auto payloadEnd = checkedAdd(payloadSize, *paddedSize);
+    if (!payloadEnd.has_value() || !byteRangeCanBeAddressed({payloadSize, *paddedSize})) {
+        return std::nullopt;
+    }
+
+    const ByteRange range{payloadSize, size};
+    payloadSize = *payloadEnd;
+    return std::pair{range, *paddedSize};
 }
 
 } // namespace mlsdk::vgflib

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -12,6 +12,7 @@ add_executable(VGFLibTests
   module_table_tests.cpp
   numpy_test.cpp
   section_index_table_tests.cpp
+  utils_tests.cpp
 )
 target_link_libraries(VGFLibTests PRIVATE
     GTest::gtest_main

--- a/test/utils_tests.cpp
+++ b/test/utils_tests.cpp
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "utils.hpp"
+
+#include <gtest/gtest.h>
+#include <limits>
+
+using namespace mlsdk::vgflib;
+
+namespace {
+
+constexpr bool byteRangeWithinBoundsConstexprTest() {
+    return byteRangeWithinBounds({0, 0}, 0) && byteRangeWithinBounds({0, 4}, 8) && byteRangeWithinBounds({4, 4}, 8) &&
+           byteRangeWithinBounds({8, 0}, 8) && !byteRangeWithinBounds({9, 0}, 8) && !byteRangeWithinBounds({5, 4}, 8);
+}
+
+constexpr bool byteRangeCanBeAddressedConstexprTest() {
+    if (!byteRangeCanBeAddressed({0, 0}) || !byteRangeCanBeAddressed({4, 8})) {
+        return false;
+    }
+
+#if SIZE_MAX < UINT64_MAX
+    constexpr uint64_t sizeMax = static_cast<uint64_t>(std::numeric_limits<size_t>::max());
+    return !byteRangeCanBeAddressed({sizeMax + 1, 0}) && !byteRangeCanBeAddressed({0, sizeMax + 1}) &&
+           !byteRangeCanBeAddressed({sizeMax, 1});
+#else
+    return byteRangeCanBeAddressed({std::numeric_limits<uint64_t>::max(), 0});
+#endif
+}
+
+constexpr bool splitFixedRecordTableConstexprTest() {
+    const auto layout = splitFixedRecordTable(64, 16, 8, 3);
+    if (!layout.has_value() || layout->records.offset != 16 || layout->records.size != 24 ||
+        layout->payload.offset != 40 || layout->payload.size != 24) {
+        return false;
+    }
+
+    const auto emptyPayloadLayout = splitFixedRecordTable(40, 16, 8, 3);
+    return emptyPayloadLayout.has_value() && emptyPayloadLayout->records.offset == 16 &&
+           emptyPayloadLayout->records.size == 24 && emptyPayloadLayout->payload.offset == 40 &&
+           emptyPayloadLayout->payload.size == 0;
+}
+
+constexpr bool splitFixedRecordTableRejectsInvalidLayoutConstexprTest() {
+    return !splitFixedRecordTable(16, 17, 8, 0).has_value() && !splitFixedRecordTable(16, 0, 0, 0).has_value() &&
+           !splitFixedRecordTable(31, 16, 8, 2).has_value();
+}
+
+constexpr bool appendAlignedByteRangeConstexprTest() {
+    uint64_t payloadSize = 0;
+    const auto first = appendAlignedByteRange(5, 8, payloadSize);
+    if (!first.has_value() || first->first.offset != 0 || first->first.size != 5 || first->second != 8 ||
+        payloadSize != 8) {
+        return false;
+    }
+
+    const auto second = appendAlignedByteRange(0, 8, payloadSize);
+    return second.has_value() && second->first.offset == 8 && second->first.size == 0 && second->second == 0 &&
+           payloadSize == 8;
+}
+
+static_assert(checkedAdd(1, 2).has_value() && *checkedAdd(1, 2) == 3);
+static_assert(!checkedAdd(std::numeric_limits<uint64_t>::max(), 1).has_value());
+static_assert(checkedMul(3, 4).has_value() && *checkedMul(3, 4) == 12);
+static_assert(!checkedMul(std::numeric_limits<uint64_t>::max(), 2).has_value());
+static_assert(checkedAlignUp(5, 8).has_value() && *checkedAlignUp(5, 8) == 8);
+static_assert(!checkedAlignUp(5, 0).has_value());
+static_assert(byteRangeWithinBoundsConstexprTest());
+static_assert(byteRangeCanBeAddressedConstexprTest());
+static_assert(splitFixedRecordTableConstexprTest());
+static_assert(splitFixedRecordTableRejectsInvalidLayoutConstexprTest());
+static_assert(appendAlignedByteRangeConstexprTest());
+
+} // namespace
+
+TEST(BinarySection, AppendAlignedByteRange) {
+    uint64_t payloadSize = 0;
+
+    const auto first = appendAlignedByteRange(5, 8, payloadSize);
+    ASSERT_TRUE(first.has_value());
+    const auto &[firstRange, firstPaddedSize] = *first;
+    EXPECT_EQ(firstRange.offset, 0);
+    EXPECT_EQ(firstRange.size, 5);
+    EXPECT_EQ(firstPaddedSize, 8);
+    EXPECT_EQ(payloadSize, 8);
+
+    const auto second = appendAlignedByteRange(8, 8, payloadSize);
+    ASSERT_TRUE(second.has_value());
+    const auto &[secondRange, secondPaddedSize] = *second;
+    EXPECT_EQ(secondRange.offset, 8);
+    EXPECT_EQ(secondRange.size, 8);
+    EXPECT_EQ(secondPaddedSize, 8);
+    EXPECT_EQ(payloadSize, 16);
+
+    const auto third = appendAlignedByteRange(0, 8, payloadSize);
+    ASSERT_TRUE(third.has_value());
+    const auto &[thirdRange, thirdPaddedSize] = *third;
+    EXPECT_EQ(thirdRange.offset, 16);
+    EXPECT_EQ(thirdRange.size, 0);
+    EXPECT_EQ(thirdPaddedSize, 0);
+    EXPECT_EQ(payloadSize, 16);
+}
+
+TEST(BinarySection, AppendAlignedByteRangeRejectsInvalidLayout) {
+    uint64_t payloadSize = 0;
+    EXPECT_FALSE(appendAlignedByteRange(1, 0, payloadSize).has_value());
+    EXPECT_EQ(payloadSize, 0);
+
+    payloadSize = std::numeric_limits<uint64_t>::max();
+    EXPECT_FALSE(appendAlignedByteRange(1, 8, payloadSize).has_value());
+    EXPECT_EQ(payloadSize, std::numeric_limits<uint64_t>::max());
+}


### PR DESCRIPTION
Add reusable helpers for validating byte ranges, splitting fixed-record sections into metadata and payload ranges, and allocating aligned payload ranges.

Use the new helpers in the raw constant section encoder and decoder while keeping the on-disk layout and chunked constant storage unchanged. Add focused unit coverage for the binary section utilities.