### PR TITLE
Fix VGF Library version reporting

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -18,8 +18,14 @@ function(mlsdk_get_git_revision SRCDIR RETURN_GIT_REVISION)
         return()
     endif()
 
+    # Refresh cached stat metadata before describe so clean checkouts do not
+    # get a false -dirty suffix. Real local changes still report as dirty.
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken
+        COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+        WORKING_DIRECTORY ${SRCDIR})
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken --long
         WORKING_DIRECTORY ${SRCDIR}
         RESULT_VARIABLE GIT_RETURN_CODE
         OUTPUT_VARIABLE GIT_OUTPUT
@@ -57,7 +63,7 @@ function(mlsdk_generate_version_header)
         set(depVersionVar "${dep}_VERSION")
         set(depVersion "unknown")
 
-        if(${depVersionVar})
+        if(DEFINED ${depVersionVar})
             set(depVersion "${${depVersionVar}}")
         else()
             message(WARNING "Unable to get version for ${dep}: ${depVersionVar} is not set")

--- a/vgf_updater/src/main.cpp
+++ b/vgf_updater/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,10 +8,11 @@
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
+#include <version.hpp>
 
 int main(int argc, char *argv[]) {
     try {
-        argparse::ArgumentParser parser(argv[0]);
+        argparse::ArgumentParser parser(argv[0], mlsdk::vgf_updater::details::version);
 
         // Set up positional args
         parser.add_argument("-i", "--input").help("The VGF input file to convert").required();


### PR DESCRIPTION
Normalize Git-derived version strings by refreshing the index before `git describe --dirty` and using long describe output for exact tags.

Use safer dependency version variable lookup in the shared CMake version helper.

Wire `vgf_updater --version` to the generated version header so it reports the same JSON version format as the other VGF tools instead of argparse's default version string.