### PR TITLE
Add missing vgfpy extension to pip wheel

### DIFF
--- a/pip_package/setup.py
+++ b/pip_package/setup.py
@@ -1,11 +1,37 @@
 #
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
+import importlib.machinery
+import pathlib
 import platform
+import shutil
 
+from setuptools import Extension
 from setuptools import setup
+from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
+
+
+# vgfpy is built by CMake before this package is assembled, so setuptools
+# needs a marker extension type for a prebuilt binary rather than sources.
+class PrebuiltExtension(Extension):
+    def __init__(self, name, path):
+        super().__init__(name, sources=[])
+        self.path = path
+
+
+# setuptools calls build_extension for each item in ext_modules. For vgfpy,
+# copy the prebuilt binary into the expected wheel location instead of compiling.
+class BuildExt(build_ext):
+    def build_extension(self, ext):
+        if isinstance(ext, PrebuiltExtension):
+            output_path = pathlib.Path(self.get_ext_fullpath(ext.name))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(ext.path, output_path)
+            return
+
+        super().build_extension(ext)
 
 
 class BDistWheel(bdist_wheel):
@@ -31,4 +57,18 @@ class BDistWheel(bdist_wheel):
         return ("py3", "none", platformName)
 
 
-setup(cmdclass={"bdist_wheel": BDistWheel})
+def get_prebuilt_extension():
+    package_dir = pathlib.Path(__file__).parent
+    for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+        extension_path = package_dir / f"vgfpy{suffix}"
+        if extension_path.exists():
+            return PrebuiltExtension("vgfpy", str(extension_path))
+    return None
+
+
+prebuilt_extension = get_prebuilt_extension()
+
+setup(
+    cmdclass={"bdist_wheel": BDistWheel, "build_ext": BuildExt},
+    ext_modules=[prebuilt_extension] if prebuilt_extension else [],
+)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import argparse
+import importlib.machinery
 import os
 import pathlib
 import platform
@@ -365,11 +366,36 @@ class Builder:
                 self.generate_cmake_package("ZIP", True)
 
             if self.package_pip:
-                os.makedirs("pip_package/vgf_lib/binaries/", exist_ok=True)
-                shutil.copytree(
-                    self.install, "pip_package/vgf_lib/binaries/", dirs_exist_ok=True
+                pip_package_dir = VGF_LIB_DIR / "pip_package"
+                pip_binaries_dir = pip_package_dir / "vgf_lib" / "binaries"
+                os.makedirs(pip_binaries_dir, exist_ok=True)
+                shutil.copytree(self.install, pip_binaries_dir, dirs_exist_ok=True)
+                shutil.copyfile("README.md", pip_package_dir / "README.md")
+
+                for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+                    for old_extension in pip_package_dir.glob(f"vgfpy{suffix}"):
+                        old_extension.unlink()
+
+                staged_extensions = []
+                for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+                    staged_extensions.extend(
+                        pathlib.Path(self.build_dir).glob(f"**/vgfpy{suffix}")
+                    )
+
+                if not staged_extensions:
+                    print("ERROR: vgfpy extension was not found in build directory")
+                    return 1
+
+                if len(staged_extensions) > 1:
+                    print(
+                        "ERROR: Multiple vgfpy extensions found in build directory, unable to determine which one to package"
+                    )
+                    return 1
+
+                shutil.copyfile(
+                    staged_extensions[0],
+                    pip_package_dir / staged_extensions[0].name,
                 )
-                shutil.copyfile("README.md", "pip_package/README.md")
 
                 package_version = ""
                 if self.package_version:
@@ -385,7 +411,7 @@ class Builder:
                 result = subprocess.Popen(
                     [sys.executable, "-m", "build"],
                     env=os.environ,
-                    cwd="pip_package",
+                    cwd=pip_package_dir,
                 )
                 result.communicate()
                 if result.returncode != 0:


### PR DESCRIPTION
Copy the built vgfpy extension into the wheel inputs before running python -m build. Use a prebuilt setuptools extension so the module is installed at top level and can be imported with `import vgfpy`.

Change-Id: I295769227e9a47478593070f25f55223cfa3e4ba