### PR TITLE
fix: Reject truncated VGF headers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,12 @@
 ## Unreleased
 
 ### Build, Packaging & Developer Experience
- - Updated vgf_dump and vgf_updater `--version` output to report the package version and include git revision and dependency revision information
+
+- Updated vgf_dump and vgf_updater `--version` output to report the package version and include git revision and dependency revision information
+
+### Bug Fixes
+
+- Hardened header decoding.
 
 ## Version 0.10.0 – *Resource Metadata & C API Expansion*
 

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -211,6 +211,10 @@ class HeaderDecoderImpl : public HeaderDecoder {
             logging::error("Header size is not the expected size");
             return nullptr;
         }
+        if (fileSize < HeaderSize()) {
+            logging::error("File size is smaller than the header size");
+            return nullptr;
+        }
         auto decoder = std::unique_ptr<HeaderDecoderImpl>(new HeaderDecoderImpl(data));
         if (!_verify(decoder.get(), fileSize)) {
             return nullptr;
@@ -226,6 +230,10 @@ class HeaderDecoderImpl : public HeaderDecoder {
         }
         if (headerSize != HeaderSize()) {
             logging::error("Header size is not the expected size");
+            return nullptr;
+        }
+        if (fileSize < HeaderSize()) {
+            logging::error("File size is smaller than the header size");
             return nullptr;
         }
         auto *decoder = new (decoderMem) HeaderDecoderImpl(data);

--- a/test/header_tests.cpp
+++ b/test/header_tests.cpp
@@ -13,7 +13,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstring>
 #include <sstream>
+#include <vector>
 
 using namespace mlsdk::vgflib;
 
@@ -85,6 +88,16 @@ TEST(CppDecode, WrongMagic) {
     ASSERT_TRUE(vgf1 == FourCC('V', 'G', 'F', '1'));
 }
 
+TEST(CppDecode, TruncatedHeaderRejected) {
+    const Header header({0, 0}, {0, 0}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
+    std::vector<uint8_t> data(HeaderSize() - 1);
+    std::memcpy(data.data(), &header, data.size());
+
+    std::unique_ptr<HeaderDecoder> decoder =
+        CreateHeaderDecoder(data.data(), static_cast<uint64_t>(HeaderSize()), static_cast<uint64_t>(data.size()));
+    ASSERT_TRUE(nullptr == decoder);
+}
+
 TEST(CppEncode, FailToWrite) {
     std::stringbuf roBuf("", std::ios_base::in); // read-only stream
     std::ostream roStream(&roBuf);
@@ -149,6 +162,19 @@ TEST(CDecode, HeaderTest) {
 
 TEST(CDecode, WrongMagic) {
     std::array<char, HEADER_HEADER_SIZE_VALUE> data = {0};
+
+    std::vector<uint8_t> decoderMemory;
+    decoderMemory.resize(mlsdk_decoder_header_decoder_mem_reqs());
+    const mlsdk_decoder_header_decoder *decoder =
+        mlsdk_decoder_create_header_decoder(data.data(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
+                                            static_cast<uint64_t>(data.size()), decoderMemory.data());
+    ASSERT_TRUE(nullptr == decoder);
+}
+
+TEST(CDecode, TruncatedHeaderRejected) {
+    const Header header({0, 0}, {0, 0}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
+    std::vector<uint8_t> data(mlsdk_decoder_header_size() - 1);
+    std::memcpy(data.data(), &header, data.size());
 
     std::vector<uint8_t> decoderMemory;
     decoderMemory.resize(mlsdk_decoder_header_decoder_mem_reqs());


### PR DESCRIPTION
Check that the file buffer is large enough to contain the full header before constructing the header decoder. This rejects callers that pass the expected header size with a truncated file buffer.

Add C++ and C API regression coverage for truncated header buffers.



Change-Id: Ie23ee94f6bed7dd3f04d01feb1daaa6f614c1ef8