### PR TITLE
fix: DataView equality byte count

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - Hardened header decoding.
+- Fixed `DataView` equality operator.
 
 ## Version 0.10.0 – *Resource Metadata & C API Expansion*
 

--- a/include/vgf/decoder.hpp
+++ b/include/vgf/decoder.hpp
@@ -43,12 +43,12 @@ template <typename T> class DataView {
             return false;
         }
 
-        return std::memcmp(ptr_, other.ptr_, size_) == 0;
+        return std::memcmp(ptr_, other.ptr_, size_ * sizeof(T)) == 0;
     }
 
   private:
     const T *ptr_ = nullptr;
-    size_t size_ = 0;
+    size_t size_ = 0; // Number of elements, not bytes.
 };
 
 /**

--- a/test/model_resource_tests.cpp
+++ b/test/model_resource_tests.cpp
@@ -55,6 +55,19 @@ TEST(DataView, Basic) {
     ASSERT_TRUE(DataViewTests());
 }
 
+TEST(DataView, EqualityRejectsDifferentUint32ElementAtAnyPosition) {
+    const std::vector<uint32_t> data{1, 2, 3, 4};
+
+    for (size_t i = 0; i < data.size(); ++i) {
+        SCOPED_TRACE(i);
+        std::vector<uint32_t> differentData = data;
+        differentData[i] = 99;
+
+        ASSERT_FALSE(DataView<uint32_t>(data.data(), data.size()) ==
+                     DataView<uint32_t>(differentData.data(), differentData.size()));
+    }
+}
+
 TEST(CppModelResourceTable, EmptyTable) {
     std::stringstream buffer;
 


### PR DESCRIPTION
Compare DataView contents using the byte length derived from the element count instead of treating the element count as bytes.

Add regression coverage for direct DataView equality.



Change-Id: I5ff0c7734654df62549a54d53b8d26b0653ac26f