### PR TITLE
refactor: Update clang-tidy config to cover c headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,13 @@
 #
 Checks: >
     -*,
+    bugprone-assert-side-effect,
+    bugprone-capturing-this-in-member-variable,
+    bugprone-copy-constructor-init,
+    bugprone-dangling-handle,
+    bugprone-move-forwarding-reference,
+    bugprone-return-const-ref-from-parameter,
+    bugprone-standalone-empty,
     bugprone-unsafe-functions,
     bugprone-use-after-move,
     cert-con36-c,
@@ -41,15 +48,21 @@ Checks: >
     cert-pos47-c,
     cert-sig30-c,
     cert-str34-c,
+    cppcoreguidelines-missing-std-forward,
+    cppcoreguidelines-pro-type-cstyle-cast,
     cppcoreguidelines-virtual-class-destructor,
     google-build-namespaces,
     misc-definitions-in-headers,
+    misc-static-assert,
     misc-unused-*,
+    misc-use-anonymous-namespace,
     modernize-deprecated-headers,
     modernize-make-unique,
     modernize-redundant-void-arg,
+    modernize-type-traits,
     modernize-use-auto,
     modernize-use-default-member-init,
+    modernize-use-equals-default,
     modernize-use-nullptr,
     modernize-use-override,
     modernize-use-using,
@@ -63,11 +76,16 @@ Checks: >
     performance-move-constructor-init,
     performance-no-automatic-move,
     performance-no-int-to-ptr,
+    performance-noexcept-destructor,
     performance-noexcept-move-constructor,
+    performance-noexcept-swap,
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
     readability-avoid-const-params-in-decls,
+    readability-avoid-nested-conditional-operator,
+    readability-avoid-return-with-void-value,
+    readability-avoid-unconditional-preprocessor-if,
     readability-braces-around-statements,
     readability-const-return-type,
     readability-container-contains,
@@ -85,16 +103,21 @@ Checks: >
     readability-misleading-indentation,
     readability-misplaced-array-index,
     readability-non-const-parameter,
+    readability-operators-representation,
     readability-qualified-auto,
     readability-redundant-access-specifiers,
+    readability-redundant-casting,
     readability-redundant-control-flow,
     readability-redundant-declaration,
     readability-redundant-function-ptr-dereference,
+    readability-redundant-inline-specifier,
     readability-redundant-member-init,
     readability-redundant-preprocessor,
     readability-redundant-smartptr-get,
     readability-redundant-string-cstr,
     readability-redundant-string-init,
+    readability-reference-to-constructed-temporary,
+    readability-simplify-boolean-expr,
     readability-simplify-subscript-expr,
     readability-static-accessed-through-instance,
     readability-static-definition-in-anonymous-namespace,
@@ -105,7 +128,7 @@ Checks: >
     readability-use-anyofallof,
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: 'vgf-lib/.+/.+\.hpp$'
+HeaderFilterRegex: 'vgf-lib/.*'
 FormatStyle: file
 CheckOptions:
   - key: bugprone-unsafe-functions.ReportDefaultFunctions
@@ -137,3 +160,5 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.StructIgnoredRegexp
     value: '.*_s'
+  - key: modernize-use-using.IgnoreExternC
+    value: true

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -43,10 +43,7 @@ bool validateSectionsSizesInHeader(const HeaderDecoder &headerDecoder, uint64_t 
             return false;
         }
         const uint64_t remaining = fileSize - offset;
-        if (size > remaining) {
-            return false;
-        }
-        return true;
+        return (size <= remaining);
     };
 
     const uint64_t moduleOffset = headerDecoder.GetModuleTableOffset();

--- a/utils/src/numpy.cpp
+++ b/utils/src/numpy.cpp
@@ -21,7 +21,12 @@ bool isLittleEndian() {
     return reinterpret_cast<uint8_t *>(&num)[1] == 0;
 }
 
-char getEndianChar(uint64_t size) { return size < 2 ? '|' : isLittleEndian() ? '<' : '>'; }
+char getEndianChar(uint64_t size) {
+    if (size < 2) {
+        return '|';
+    }
+    return isLittleEndian() ? '<' : '>';
+}
 
 uint64_t sizeOf(const std::vector<int64_t> &shape, const uint64_t &itemsize) {
     return std::accumulate(shape.begin(), shape.end(), itemsize, std::multiplies<uint64_t>());
@@ -109,11 +114,7 @@ bool checkFortranOrder(const std::string &dict) {
     }
 
     const auto valuePos = dict.find("False", keyPos);
-    if (valuePos == std::string::npos || valuePos != keyPos + 17) {
-        return false;
-    }
-
-    return true;
+    return (valuePos != std::string::npos) && (valuePos == keyPos + 17);
 }
 
 void writeHeader(std::ostream &out, const std::vector<int64_t> &shape, const std::string &dtype) {
@@ -302,7 +303,7 @@ void write(const std::string &filename, const char *ptr, const std::vector<int64
     writeHeader(file, shape, dtypeToStr(dtype));
 
     // write data to file
-    file.write(reinterpret_cast<const char *>(ptr), std::streamsize(sizeOf(shape, itemsize)));
+    file.write(ptr, std::streamsize(sizeOf(shape, itemsize)));
     file.close();
 }
 

--- a/vgf_updater/src/vgf_updater.cpp
+++ b/vgf_updater/src/vgf_updater.cpp
@@ -231,9 +231,8 @@ auto encodeSegments(const ModelSequence &sequenceTable, const std::vector<Module
                     modelOutputBindingSlots.push_back(binding);
                 }
             }
-            const auto descriptorPosition = static_cast<uint32_t>(descriptorIdx);
             const uint32_t encodedSetIndex =
-                (dscInfo.mSetIndex == descriptorPosition) ? std::numeric_limits<uint32_t>::max() : dscInfo.mSetIndex;
+                (dscInfo.mSetIndex == descriptorIdx) ? std::numeric_limits<uint32_t>::max() : dscInfo.mSetIndex;
             descriptorSetInfoRefs.push_back(encoder.AddDescriptorSetInfo(descriptorBindingSlotsRefs, encodedSetIndex));
             ++descriptorIdx;
         }

--- a/vgf_updater/test/vgf_updater_tests.cpp
+++ b/vgf_updater/test/vgf_updater_tests.cpp
@@ -16,7 +16,7 @@
 namespace fs = std::filesystem;
 
 namespace {
-::testing::AssertionResult compareFiles(fs::path fileOne, fs::path fileTwo) {
+::testing::AssertionResult compareFiles(const fs::path &fileOne, const fs::path &fileTwo) {
     const auto fileOneSize = fs::file_size(fileOne);
     const auto fileTwoSize = fs::file_size(fileTwo);
     if (fileOneSize != fileTwoSize) {
@@ -47,8 +47,7 @@ namespace {
     std::vector<char> fileTwoBuffer(fileTwoSize);
     fileTwoBytes.read(fileTwoBuffer.data(), static_cast<std::streamsize>(fileTwoSize));
 
-    return std::equal(std::istreambuf_iterator<char>(fileOneBytes.rdbuf()), std::istreambuf_iterator<char>(),
-                      std::istreambuf_iterator<char>(fileTwoBytes.rdbuf()))
+    return std::equal(fileOneBuffer.begin(), fileOneBuffer.end(), fileTwoBuffer.begin())
                ? testing::AssertionSuccess()
                : testing::AssertionFailure() << "Compared files " << fileOne << " and " << fileTwo << " are different.";
 }


### PR DESCRIPTION
Also enable some more checkers to align with other components.

Change-Id: Icf0c4bcbe888422e663f3c5aef1e072df2e1345a