### PR TITLE
chore: fix license header for previous change to include 2026

### DIFF
--- a/samples/1_encode_simple_graph_sample.cpp
+++ b/samples/1_encode_simple_graph_sample.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/samples/3_encode_simple_graph_with_constants_sample.cpp
+++ b/samples/3_encode_simple_graph_with_constants_sample.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Change-Id: I103fa60c7c3e7f09a81764a2a527088a95d795bd