### PR TITLE
fix(decoder): validate section alignment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Hardened header decoding.
+- Rejected misaligned section offsets in VGF 0.4.3 and newer during header decoding.
 - Fixed `DataView` equality operator.
 
 ### Highlights

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -67,6 +67,23 @@ bool validateSectionsSizesInHeader(const HeaderDecoder &headerDecoder, uint64_t 
     return true;
 }
 
+bool validateSectionAlignmentsInHeader(const HeaderDecoder &headerDecoder) {
+    constexpr FormatVersion ALIGNED_SECTION_VERSION{0, 4, 3};
+    const auto version = headerDecoder.GetVersion();
+    if (std::tie(version.major, version.minor, version.patch) <
+        std::tie(ALIGNED_SECTION_VERSION.major, ALIGNED_SECTION_VERSION.minor, ALIGNED_SECTION_VERSION.patch)) {
+        return true;
+    }
+
+    const auto isAligned = [](uint64_t offset) { return offset % VGF_SECTION_ALIGNMENT_VALUE == 0; };
+    if (!isAligned(headerDecoder.GetModuleTableOffset()) || !isAligned(headerDecoder.GetModelSequenceTableOffset()) ||
+        !isAligned(headerDecoder.GetModelResourceTableOffset()) || !isAligned(headerDecoder.GetConstantsOffset())) {
+        logging::error("section alignment invalid (alignment=" + std::to_string(VGF_SECTION_ALIGNMENT_VALUE) + ")");
+        return false;
+    }
+    return true;
+}
+
 // FlatBuffers uses 32-bit offsets; cap verification to what the format can encode and what the platform can address.
 constexpr uint64_t maxFlatbufferBytes() {
     constexpr auto UOFFSET_MAX = static_cast<uint64_t>(std::numeric_limits<flatbuffers::uoffset_t>::max());
@@ -303,6 +320,9 @@ class HeaderDecoderImpl : public HeaderDecoder {
             return false;
         }
         if (!validateSectionsSizesInHeader(*decoder, fileSize)) {
+            return false;
+        }
+        if (!validateSectionAlignmentsInHeader(*decoder)) {
             return false;
         }
         return true;

--- a/test/header_tests.cpp
+++ b/test/header_tests.cpp
@@ -98,6 +98,30 @@ TEST(CppDecode, TruncatedHeaderRejected) {
     ASSERT_TRUE(nullptr == decoder);
 }
 
+TEST(CppDecode, MisalignedCurrentFormatSectionRejected) {
+    constexpr uint64_t MISSALIGNED_OFFSET = HEADER_HEADER_SIZE_VALUE + 4;
+    const Header header({MISSALIGNED_OFFSET, 0}, {0, 0}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
+    std::vector<uint8_t> data(MISSALIGNED_OFFSET);
+    std::memcpy(data.data(), &header, sizeof(Header));
+
+    const auto decoder =
+        CreateHeaderDecoder(data.data(), static_cast<uint64_t>(HeaderSize()), static_cast<uint64_t>(data.size()));
+    ASSERT_EQ(nullptr, decoder);
+}
+
+TEST(CppDecode, MisalignedLegacyFormatSectionAccepted) {
+    constexpr uint64_t MISSALIGNED_OFFSET = HEADER_HEADER_SIZE_VALUE + 4;
+    const Header header({MISSALIGNED_OFFSET, 0}, {0, 0}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
+    std::vector<uint8_t> data(MISSALIGNED_OFFSET);
+    std::memcpy(data.data(), &header, sizeof(Header));
+    constexpr FormatVersion LEGACY_VERSION{0, 4, 2};
+    std::memcpy(data.data() + HEADER_VERSION_OFFSET, &LEGACY_VERSION, sizeof(LEGACY_VERSION));
+
+    const auto decoder =
+        CreateHeaderDecoder(data.data(), static_cast<uint64_t>(HeaderSize()), static_cast<uint64_t>(data.size()));
+    ASSERT_NE(nullptr, decoder);
+}
+
 TEST(CppEncode, FailToWrite) {
     std::stringbuf roBuf("", std::ios_base::in); // read-only stream
     std::ostream roStream(&roBuf);

--- a/test/model_resource_tests.cpp
+++ b/test/model_resource_tests.cpp
@@ -365,7 +365,7 @@ TEST(CppVerify, ModelResourceMisalignedRejected) {
     Header header({0, 0}, {0, 0}, {resourceOffset, resourceSize}, {0, 0}, pretendVulkanHeaderVersion);
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
-    EXPECT_NE(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
+    EXPECT_EQ(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
                                            static_cast<uint64_t>(buffer.size())));
     EXPECT_EQ(nullptr, CreateModelResourceTableDecoder(buffer.data() + resourceOffset, resourceSize));
     EXPECT_TRUE(logger.contains({"VerifyModelResourceTable", "data alignment invalid"}));
@@ -766,7 +766,7 @@ TEST(CVerify, ModelResourceMisalignedRejected) {
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
     std::vector<uint8_t> headerDecoderMemory(mlsdk_decoder_header_decoder_mem_reqs());
-    EXPECT_NE(nullptr,
+    EXPECT_EQ(nullptr,
               mlsdk_decoder_create_header_decoder(buffer.data(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
                                                   static_cast<uint64_t>(buffer.size()), headerDecoderMemory.data()));
     std::vector<uint8_t> decoderMem(mlsdk_decoder_model_resource_table_decoder_mem_reqs());

--- a/test/model_sequence_tests.cpp
+++ b/test/model_sequence_tests.cpp
@@ -612,7 +612,7 @@ TEST(CppVerify, ModelSequenceMisalignedRejected) {
     Header header({0, 0}, {sequenceOffset, sequenceSize}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
-    EXPECT_NE(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
+    EXPECT_EQ(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
                                            static_cast<uint64_t>(buffer.size())));
     EXPECT_EQ(nullptr, CreateModelSequenceTableDecoder(buffer.data() + sequenceOffset, sequenceSize));
     EXPECT_TRUE(logger.contains({"VerifyModelSequenceTable", "data alignment invalid"}));
@@ -1249,7 +1249,7 @@ TEST(CVerify, ModelSequenceMisalignedRejected) {
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
     std::vector<uint8_t> headerDecoderMemory(mlsdk_decoder_header_decoder_mem_reqs());
-    EXPECT_NE(nullptr,
+    EXPECT_EQ(nullptr,
               mlsdk_decoder_create_header_decoder(buffer.data(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
                                                   static_cast<uint64_t>(buffer.size()), headerDecoderMemory.data()));
     std::vector<uint8_t> decoderMem(mlsdk_decoder_model_sequence_decoder_mem_reqs());

--- a/test/module_table_tests.cpp
+++ b/test/module_table_tests.cpp
@@ -231,7 +231,7 @@ TEST(CppVerify, ModuleMisalignedRejected) {
     Header header({moduleOffset, moduleSize}, {0, 0}, {0, 0}, {0, 0}, pretendVulkanHeaderVersion);
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
-    EXPECT_NE(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
+    EXPECT_EQ(nullptr, CreateHeaderDecoder(buffer.data(), static_cast<uint64_t>(HeaderSize()),
                                            static_cast<uint64_t>(buffer.size())));
     EXPECT_EQ(nullptr, CreateModuleTableDecoder(buffer.data() + moduleOffset, moduleSize));
     EXPECT_TRUE(logger.contains({"VerifyModuleTable", "data alignment invalid"}));
@@ -502,7 +502,7 @@ TEST(CVerify, ModuleMisalignedRejected) {
     std::memcpy(buffer.data(), &header, sizeof(Header));
 
     std::vector<uint8_t> headerDecoderMemory(mlsdk_decoder_header_decoder_mem_reqs());
-    EXPECT_NE(nullptr,
+    EXPECT_EQ(nullptr,
               mlsdk_decoder_create_header_decoder(buffer.data(), static_cast<uint64_t>(mlsdk_decoder_header_size()),
                                                   static_cast<uint64_t>(buffer.size()), headerDecoderMemory.data()));
     std::vector<uint8_t> decoderMem(mlsdk_decoder_module_table_decoder_mem_reqs());


### PR DESCRIPTION
Reject misaligned section offsets during header decoding for VGF 0.4.3 and newer, before constructing table decoders. Preserve compatibility with older format versions.

Update the C and C++ misalignment tests to expect the earlier rejection and cover the version boundary explicitly.

Change-Id: Id16ef1b5c732aaeb4e2c91facadc45fe4aa0c4c1