### PR TITLE
feat(vgf-utils): validate memory map alignment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@
 
 ### Highlights
 
+- Added optional zero-copy alignment validation and move support to the `MemoryMap` utility.
 - Added per-segment graph constant bindings to map SPIR-V™ graph constant IDs to VGF constant table entries.
 - Added C++, C, and Python APIs for encoding and decoding explicit graph constant bindings.
 - Preserved legacy segment constant lists as identity bindings for older VGF files and callers.

--- a/include/vgf-utils/memory_map.hpp
+++ b/include/vgf-utils/memory_map.hpp
@@ -4,15 +4,19 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 class MemoryMap {
   public:
     explicit MemoryMap(const std::string &filename);
+    /// Maps filename and throws if its base address does not satisfy requiredAlignment.
+    /// No aligned copy is made.
+    MemoryMap(const std::string &filename, size_t requiredAlignment);
     MemoryMap(const MemoryMap &) = delete;
     MemoryMap &operator=(const MemoryMap &) = delete;
-    MemoryMap(const MemoryMap &&) = delete;
-    MemoryMap &operator=(const MemoryMap &&) = delete;
+    MemoryMap(MemoryMap &&other) noexcept;
+    MemoryMap &operator=(MemoryMap &&other) noexcept;
 
     ~MemoryMap();
 
@@ -21,11 +25,13 @@ class MemoryMap {
 
   private:
 #ifdef _WIN32
-    void *hFile_;
-    void *hMap_;
+    void *hFile_{};
+    void *hMap_{};
 #else
-    int fd_;
+    int fd_{-1};
 #endif
-    void *addr_;
-    size_t size_;
+    void *addr_{};
+    size_t size_{};
+
+    void reset() noexcept;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(VGFLibTests
   constant_tests.cpp
   header_tests.cpp
   logging_tests.cpp
+  memory_map_tests.cpp
   model_resource_tests.cpp
   model_sequence_tests.cpp
   module_table_tests.cpp

--- a/test/memory_map_tests.cpp
+++ b/test/memory_map_tests.cpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "vgf-utils/memory_map.hpp"
+#include "vgf-utils/temp_folder.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <vector>
+
+namespace {
+
+std::filesystem::path writeFile(const TempFolder &tempFolder, const std::vector<uint8_t> &data) {
+    const auto path = tempFolder.relative("mapped.bin");
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char *>(data.data()), static_cast<std::streamsize>(data.size()));
+    return path;
+}
+
+} // namespace
+
+TEST(MemoryMap, PreservesMappedFileContents) {
+    const TempFolder tempFolder("memory_map");
+    const std::vector<uint8_t> expectedData{0x10, 0x20, 0x30};
+    const auto path = writeFile(tempFolder, expectedData);
+
+    const MemoryMap mapped(path.string());
+
+    EXPECT_EQ(mapped.size(), expectedData.size());
+    EXPECT_EQ(std::memcmp(mapped.ptr(), expectedData.data(), expectedData.size()), 0);
+}
+
+TEST(MemoryMap, AcceptsSatisfiedRequiredAlignment) {
+    const TempFolder tempFolder("memory_map");
+    const auto path = writeFile(tempFolder, {0x01});
+
+    const MemoryMap mapped(path.string(), 1);
+
+    EXPECT_EQ(mapped.size(), 1);
+}
+
+TEST(MemoryMap, RejectsInvalidRequiredAlignment) {
+    const TempFolder tempFolder("memory_map");
+    const auto path = writeFile(tempFolder, {0x01});
+
+    EXPECT_THROW(MemoryMap(path.string(), 0), std::invalid_argument);
+    EXPECT_THROW(MemoryMap(path.string(), 3), std::invalid_argument);
+}
+
+TEST(MemoryMap, RejectsRequiredAlignmentNotMetByMapping) {
+    const TempFolder tempFolder("memory_map");
+    const auto path = writeFile(tempFolder, {0x01});
+    constexpr size_t UNSUPPORTED_ALIGNMENT = size_t{1} << (std::numeric_limits<size_t>::digits - 1);
+
+    EXPECT_THROW(MemoryMap(path.string(), UNSUPPORTED_ALIGNMENT), std::runtime_error);
+}

--- a/utils/src/memory_map.cpp
+++ b/utils/src/memory_map.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "vgf-utils/memory_map.hpp"
@@ -9,6 +9,9 @@
 #include <sys/types.h>
 
 #ifdef _WIN32
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
 #    include <windows.h>
 
 #    include <fileapi.h>
@@ -17,62 +20,137 @@
 #    include <unistd.h>
 #endif
 
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
+#include <utility>
 
-MemoryMap::MemoryMap(const std::string &filename) {
+namespace {
+
+bool isPowerOfTwo(size_t value) noexcept { return value != 0 && (value & (value - 1)) == 0; }
+
+} // namespace
+
+MemoryMap::MemoryMap(const std::string &filename) : MemoryMap(filename, 1) {}
+
+MemoryMap::MemoryMap(const std::string &filename, size_t requiredAlignment) {
+    if (!isPowerOfTwo(requiredAlignment)) {
+        throw std::invalid_argument("MemoryMap alignment must be a non-zero power of two");
+    }
+
+    try {
 #ifdef _WIN32
-    HANDLE hFile = CreateFile(filename.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING,
-                              FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
-    if (hFile == INVALID_HANDLE_VALUE) {
-        throw std::runtime_error("Could not open file " + filename);
-    }
-    hFile_ = reinterpret_cast<void *>(hFile);
+        const HANDLE hFile = CreateFile(filename.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                                        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            throw std::runtime_error("Could not open file " + filename);
+        }
+        hFile_ = reinterpret_cast<void *>(hFile);
 
-    LARGE_INTEGER fileSize;
-    if (!GetFileSizeEx(hFile_, &fileSize)) {
-        throw std::runtime_error("Failed to get file size for " + filename);
-    }
-    size_ = static_cast<size_t>(fileSize.QuadPart);
+        LARGE_INTEGER fileSize;
+        if (!GetFileSizeEx(hFile, &fileSize)) {
+            throw std::runtime_error("Failed to get file size for " + filename);
+        }
+        if (fileSize.QuadPart < 0 ||
+            static_cast<std::uintmax_t>(fileSize.QuadPart) > std::numeric_limits<size_t>::max()) {
+            throw std::runtime_error("File is too large to memory map " + filename);
+        }
+        size_ = static_cast<size_t>(fileSize.QuadPart);
 
-    HANDLE hMap = CreateFileMapping(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-    if (hMap == INVALID_HANDLE_VALUE) {
-        throw std::runtime_error("Failed to create file mapping for file " + filename);
-    }
-    hMap_ = reinterpret_cast<void *>(hMap);
+        const HANDLE hMap = CreateFileMapping(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (hMap == nullptr) {
+            throw std::runtime_error("Failed to create file mapping for file " + filename);
+        }
+        hMap_ = reinterpret_cast<void *>(hMap);
 
-    addr_ = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
-    if (addr_ == nullptr) {
-        throw std::runtime_error("MapViewOfFile failed for file " + filename);
-    }
+        addr_ = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+        if (addr_ == nullptr) {
+            throw std::runtime_error("MapViewOfFile failed for file " + filename);
+        }
 #else
-    fd_ = open(filename.c_str(), O_RDONLY);
-    if (fd_ < 0) {
-        throw std::runtime_error("Could not open file " + filename);
-    }
-    struct stat st = {};
-    if (fstat(fd_, &st) == -1) {
-        throw std::runtime_error("Could not read attributes of file " + filename);
-    }
-    size_ = size_t(st.st_size);
+        fd_ = open(filename.c_str(), O_RDONLY);
+        if (fd_ < 0) {
+            throw std::runtime_error("Could not open file " + filename);
+        }
+        struct stat st = {};
+        if (fstat(fd_, &st) == -1) {
+            throw std::runtime_error("Could not read attributes of file " + filename);
+        }
+        if (st.st_size < 0 || static_cast<std::uintmax_t>(st.st_size) > std::numeric_limits<size_t>::max()) {
+            throw std::runtime_error("File is too large to memory map " + filename);
+        }
+        size_ = static_cast<size_t>(st.st_size);
 
-    addr_ = mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
-    if (addr_ == MAP_FAILED) {
-        throw std::runtime_error("Failed to memory map the file " + filename);
-    }
+        void *address = mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+        if (address == MAP_FAILED) {
+            throw std::runtime_error("Failed to memory map the file " + filename);
+        }
+        addr_ = address;
 #endif
+
+        if ((reinterpret_cast<std::uintptr_t>(addr_) & (requiredAlignment - 1)) != 0) {
+            throw std::runtime_error("Memory mapping for file " + filename +
+                                     " does not satisfy the required alignment of " +
+                                     std::to_string(requiredAlignment) + " bytes");
+        }
+    } catch (...) {
+        reset();
+        throw;
+    }
 }
 
-MemoryMap::~MemoryMap() {
+MemoryMap::MemoryMap(MemoryMap &&other) noexcept
+    :
 #ifdef _WIN32
-    UnmapViewOfFile(addr_);
-    CloseHandle(reinterpret_cast<HANDLE>(hMap_));
-    CloseHandle(reinterpret_cast<HANDLE>(hFile_));
+      hFile_(std::exchange(other.hFile_, nullptr)), hMap_(std::exchange(other.hMap_, nullptr)),
 #else
-    if (fd_ > 0) {
+      fd_(std::exchange(other.fd_, -1)),
+#endif
+      addr_(std::exchange(other.addr_, nullptr)), size_(std::exchange(other.size_, 0)) {
+}
+
+MemoryMap &MemoryMap::operator=(MemoryMap &&other) noexcept {
+    if (this != &other) {
+        reset();
+#ifdef _WIN32
+        hFile_ = std::exchange(other.hFile_, nullptr);
+        hMap_ = std::exchange(other.hMap_, nullptr);
+#else
+        fd_ = std::exchange(other.fd_, -1);
+#endif
+        addr_ = std::exchange(other.addr_, nullptr);
+        size_ = std::exchange(other.size_, 0);
+    }
+    return *this;
+}
+
+MemoryMap::~MemoryMap() { reset(); }
+
+void MemoryMap::reset() noexcept {
+#ifdef _WIN32
+    if (addr_ != nullptr) {
+        UnmapViewOfFile(addr_);
+        addr_ = nullptr;
+    }
+    if (hMap_ != nullptr) {
+        CloseHandle(reinterpret_cast<HANDLE>(hMap_));
+        hMap_ = nullptr;
+    }
+    if (hFile_ != nullptr) {
+        CloseHandle(reinterpret_cast<HANDLE>(hFile_));
+        hFile_ = nullptr;
+    }
+#else
+    if (addr_ != nullptr) {
         munmap(addr_, size_);
+        addr_ = nullptr;
+    }
+    if (fd_ >= 0) {
         close(fd_);
+        fd_ = -1;
     }
 #endif
+    size_ = 0;
 }
 
 const void *MemoryMap::ptr(const size_t offset) const {


### PR DESCRIPTION
Add a zero-copy alignment requirement to MemoryMap while preserving the existing constructor API. Make mapping ownership movable and constructor failures exception-safe.

Change-Id: I675b986ef76482d332baec3a4d562486dab811ec