### PR TITLE
refactor(pybind): pass module to initializers by reference

### DIFF
--- a/src/decoder_py.cpp
+++ b/src/decoder_py.cpp
@@ -78,7 +78,7 @@ class PyHeaderDecoder final : public HeaderDecoder {
     }
 };
 
-void pyInitHeaderDecoder(py::module m) {
+void pyInitHeaderDecoder(py::module_ &m) {
 
     py::class_<FormatVersion>(m, "FormatVersion")
         .def(py::init<>())
@@ -202,7 +202,7 @@ class PyModuleTableDecoder final : public ModuleTableDecoder {
     }
 };
 
-void pyInitModuleTableDecoder(py::module m) {
+void pyInitModuleTableDecoder(py::module_ &m) {
 
     py::class_<ModuleTableDecoder, PyModuleTableDecoder>(m, "ModuleTableDecoder")
         .def(py::init<>())
@@ -380,7 +380,7 @@ class PyModelSequenceTableDecoder final : public ModelSequenceTableDecoder {
     }
 };
 
-void pyInitModelSequenceTableDecoder(py::module m) {
+void pyInitModelSequenceTableDecoder(py::module_ &m) {
 
     py::class_<GraphConstantBinding>(m, "GraphConstantBinding")
         .def(py::init<>())
@@ -518,7 +518,7 @@ class PyModelResourceTableDecoder final : public ModelResourceTableDecoder {
     }
 };
 
-void pyInitModelResourceTableDecoder(py::module m) {
+void pyInitModelResourceTableDecoder(py::module_ &m) {
     py::class_<ModelResourceTableDecoder, PyModelResourceTableDecoder>(m, "ModelResourceTableDecoder")
         .def(py::init<>())
         .def("size", &ModelResourceTableDecoder::size)
@@ -582,7 +582,7 @@ class PyConstantDecoder final : public ConstantDecoder {
     }
 };
 
-void pyInitConstantDecoder(py::module m) {
+void pyInitConstantDecoder(py::module_ &m) {
 
     py::class_<ConstantDecoder, PyConstantDecoder>(m, "ConstantDecoder")
         .def(py::init<>())
@@ -604,7 +604,7 @@ void pyInitConstantDecoder(py::module m) {
 
 // Python Binding Module Decoder Setup
 
-void pyInitDecoder(const py::module &m) {
+void pyInitDecoder(py::module_ &m) {
 
     py::class_<BindingSlotArrayHandle_s>(m, "BindingSlotArrayHandle_s").def(py::init<>());
     py::class_<NameArrayHandle_s>(m, "NameArrayHandle_s").def(py::init<>());

--- a/src/encoder_py.cpp
+++ b/src/encoder_py.cpp
@@ -122,7 +122,7 @@ class PyEncoder final : public Encoder {
     bool WriteTo(std::ostream &output) override { PYBIND11_OVERRIDE_PURE(bool, Encoder, WriteTo, output); }
 };
 
-void pyInitEncoder(py::module m) {
+void pyInitEncoder(py::module_ &m) {
 
     py::class_<ModuleRef>(m, "ModuleRef").def(py::init<uint32_t>()).def_readonly("reference", &ModuleRef::reference);
     py::class_<ResourceRef>(m, "ResourceRef")

--- a/src/types_py.cpp
+++ b/src/types_py.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 using namespace mlsdk::vgflib;
 
-void pyInitTypes(py::module m) {
+void pyInitTypes(py::module_ &m) {
 
     py::enum_<ModuleType>(m, "ModuleType").value("Compute", ModuleType::COMPUTE).value("Graph", ModuleType::GRAPH);
 

--- a/src/vgf_py.cpp
+++ b/src/vgf_py.cpp
@@ -7,9 +7,9 @@
 
 namespace py = pybind11;
 
-extern void pyInitTypes(py::module m);
-extern void pyInitEncoder(py::module m);
-extern void pyInitDecoder(const py::module &m);
+extern void pyInitTypes(py::module_ &m);
+extern void pyInitEncoder(py::module_ &m);
+extern void pyInitDecoder(py::module_ &m);
 
 PYBIND11_MODULE(vgfpy, m) {
     pyInitTypes(m);


### PR DESCRIPTION
Use py::module_& consistently for binding initialization functions, matching PYBIND11_MODULE and avoiding unnecessary reference-count operations.

Change-Id: I1ace74d64c945bc2ed016e3b06bbc33e0a559f64