### PR TITLE
chore: enable clang-tidy analysis for VGF headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -145,7 +145,6 @@ Checks: >
     cppcoreguidelines-virtual-class-destructor,
     google-build-explicit-make-pair,
     google-build-namespaces,
-    google-default-arguments,
     google-explicit-constructor,
     google-global-names-in-headers,
     google-readability-avoid-underscore-in-googletest-name,
@@ -273,9 +272,10 @@ Checks: >
     readability-use-std-min-max,
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: 'vgf-lib/.*'
 FormatStyle: file
 CheckOptions:
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true
   - key: bugprone-unsafe-functions.ReportDefaultFunctions
     value: 'true'
   - key: bugprone-unsafe-functions.ReportMoreUnsafeFunctions

--- a/include/vgf-utils/temp_folder.hpp
+++ b/include/vgf-utils/temp_folder.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,6 +12,10 @@ class TempFolder {
   public:
     explicit TempFolder(std::string_view prefix);
     ~TempFolder();
+    TempFolder(const TempFolder &) = delete;
+    TempFolder &operator=(const TempFolder &) = delete;
+    TempFolder(TempFolder &&) = delete;
+    TempFolder &operator=(TempFolder &&) = delete;
 
     std::filesystem::path &path();
     std::filesystem::path relative(std::string_view path) const;

--- a/include/vgf/decoder.hpp
+++ b/include/vgf/decoder.hpp
@@ -35,11 +35,11 @@ template <typename T> class DataView {
             return false;
         }
 
-        if (!ptr_ && !other.ptr_) {
+        if (ptr_ == nullptr && other.ptr_ == nullptr) {
             return true;
         }
 
-        if (!ptr_ || !other.ptr_) {
+        if (ptr_ == nullptr || other.ptr_ == nullptr) {
             return false;
         }
 

--- a/include/vgf/encoder.hpp
+++ b/include/vgf/encoder.hpp
@@ -17,6 +17,16 @@
 
 namespace mlsdk::vgflib {
 
+namespace detail {
+struct ModuleRefTag {};
+struct ResourceRefTag {};
+struct ConstantRefTag {};
+struct BindingSlotRefTag {};
+struct DescriptorSetInfoRefTag {};
+struct SegmentInfoRefTag {};
+struct PushConstRangeRefTag {};
+} // namespace detail
+
 template <typename> class Ref {
   public:
     using RefType = uint32_t;
@@ -29,36 +39,38 @@ template <typename> class Ref {
  */
 
 /// \brief Class to store reference to a Module
-class ModuleRef : public Ref<ModuleRef> {};
+class ModuleRef : public Ref<detail::ModuleRefTag> {};
 
 /// \brief Class to store reference to a Resource
-class ResourceRef : public Ref<ResourceRef> {};
+class ResourceRef : public Ref<detail::ResourceRefTag> {};
 
 /// \brief Class to store reference to a Constant
-class ConstantRef : public Ref<ConstantRef> {};
+class ConstantRef : public Ref<detail::ConstantRefTag> {};
 
 /// \brief Class to store reference to a graph constant binding
 struct GraphConstantBindingRef {
     GraphConstantBindingRef() = default;
     GraphConstantBindingRef(uint32_t graphConstantId, ConstantRef constant)
         : graphConstantId(graphConstantId), constant(constant) {}
-    GraphConstantBindingRef(ConstantRef constant) : graphConstantId(constant.reference), constant(constant) {}
+    // Implicit conversion is required when adapting legacy constant-reference ranges.
+    GraphConstantBindingRef(ConstantRef constant) // NOLINT(google-explicit-constructor)
+        : graphConstantId(constant.reference), constant(constant) {}
 
     uint32_t graphConstantId = 0;
     ConstantRef constant = {0};
 };
 
 /// \brief Class to store reference to a Binding Slot
-class BindingSlotRef : public Ref<BindingSlotRef> {};
+class BindingSlotRef : public Ref<detail::BindingSlotRefTag> {};
 
 /// \brief Class to store reference to a Descriptor Set
-class DescriptorSetInfoRef : public Ref<DescriptorSetInfoRef> {};
+class DescriptorSetInfoRef : public Ref<detail::DescriptorSetInfoRefTag> {};
 
 /// \brief Class to store reference to Segment Info
-class SegmentInfoRef : public Ref<SegmentInfoRef> {};
+class SegmentInfoRef : public Ref<detail::SegmentInfoRefTag> {};
 
 /// \brief Class to store reference to a Push Constant Range
-class PushConstRangeRef : public Ref<PushConstRangeRef> {};
+class PushConstRangeRef : public Ref<detail::PushConstRangeRefTag> {};
 
 class Encoder {
   public:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -307,6 +307,8 @@ class Builder:
                     "-quiet",
                     f"-j{self.threads}",
                     f"-p{self.build_dir}",
+                    "-header-filter=vgf-lib/.*",
+                    r"-exclude-header-filter=.*\.generated\.hpp$",
                     "-extra-arg=-Wno-ignored-optimization-argument",
                     # Keep zero-argument pybind11 overrides valid when clang-tidy
                     # analyzes a C++17 compile database.

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace mlsdk::vgflib {
 
@@ -68,6 +69,8 @@ constexpr uint8_t HEADER_PATCH_VERSION_VALUE = 0;
 // * HEADER_MAGIC_VALUE_OLD
 static_assert(HEADER_MAJOR_VERSION_VALUE == 0);
 
+// Header must remain trivially copyable because it represents the serialized wire format.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct Header {
     Header(const SectionEntry &moduleSection, const SectionEntry &sequenceSection, const SectionEntry &resourceSection,
            const SectionEntry &constantSection, uint16_t vkHeaderVersion)
@@ -108,6 +111,7 @@ struct Header {
     const uint64_t reserved8{0};
 };
 
+static_assert(std::is_trivially_copyable_v<Header>, "Header must remain trivially copyable.");
 static_assert(sizeof(Header) == HEADER_HEADER_SIZE_VALUE, "Header size mismatched from spec.");
 static_assert(offsetof(Header, magic) == HEADER_MAGIC_OFFSET, "Magic field offset mismatched from spec.");
 static_assert(offsetof(Header, vkHeaderVersion) == HEADER_VK_HEADER_VERSION_OFFSET,

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -27,6 +27,10 @@ class Logger {
     Logger() {
         EnableLogging([this](LogLevel, const std::string &message) { messages_.push_back(message); });
     }
+    Logger(const Logger &) = delete;
+    Logger &operator=(const Logger &) = delete;
+    Logger(Logger &&) = delete;
+    Logger &operator=(Logger &&) = delete;
 
     ~Logger() { DisableLogging(); }
 


### PR DESCRIPTION
Pass header filtering explicitly to run-clang-tidy to work around the HeaderFilterRegex configuration bug in clang-tidy 20.1.2.

Fix the newly exposed header diagnostics, exclude generated Vulkan headers, and remove google-default-arguments because it conflicts with the existing virtual API design.

Add a compile-time assertion ensuring that the serialized Header structure remains trivially copyable.